### PR TITLE
Add CI to build and push cloud-v3 Docker image

### DIFF
--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -1,0 +1,58 @@
+name: Create and publish Docker images (cloud-v3)
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+env:
+  IMAGE_NAME: ${{ github.repository }}-cloud-v3
+  IMAGE_REGISTRY: ghcr.io
+  REGISTRY_USER: ${{ github.actor }}
+  REGISTRY_PASSWORD: ${{ github.token }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@40891eba8c2bcd1309b07ba8b11232f313e86779
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e
+        with:
+          images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
+        with:
+          context: cloud-v3/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -157,11 +157,19 @@ jobs:
           for tag in ${{ steps.meta.outputs.tags }}; do
             echo "Creating manifest for $tag"
             
-            # The source manifests are already lists because of provenance, so we need to extract the digest from the list.
-            __amd64_digest=$(docker manifest inspect ${tag}-amd64 | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-            __arm64_digest=$(docker manifest inspect ${tag}-arm64 | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
+            # Combine all manifests into a single manifest
+            __amd64_digests=$(docker manifest inspect ${tag}-amd64 | jq -r '.manifests[] | .digest')
+            __arm64_digests=$(docker manifest inspect ${tag}-arm64 | jq -r '.manifests[] | .digest')
 
-            docker manifest create ${tag} ${IMAGE_REGISTRY}/${IMAGE_NAME}@${__amd64_digest} ${IMAGE_REGISTRY}/${IMAGE_NAME}@${__arm64_digest}
+            __sources=()
+            for digest in $__amd64_digests; do
+              __sources+=(${IMAGE_REGISTRY}/${IMAGE_NAME}@${digest})
+            done
+            for digest in $__arm64_digests; do
+              __sources+=(${IMAGE_REGISTRY}/${IMAGE_NAME}@${digest})
+            done
+
+            docker manifest create ${tag} ${__sources[@]}
 
             docker manifest push ${tag}
           done

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -111,3 +111,57 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  create-multi-arch-manifest:
+    runs-on: ubuntu-latest
+    needs:
+      - build-amd64
+      - build-arm64
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@40891eba8c2bcd1309b07ba8b11232f313e86779
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e
+        with:
+          images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=long
+
+      - name: Print tags for debugging
+        run: |
+          echo "tags: ${{ steps.meta.outputs.tags }}"
+          echo "labels: ${{ steps.meta.outputs.labels }}"
+
+      - name: Create multi-arch manifests
+        run: |
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            echo "Creating manifest for $tag"
+            
+            # The source manifests are already lists because of provenance, so we need to extract the digest from the list.
+            __amd64_digest=$(docker manifest inspect ${tag}-amd64 | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
+            __arm64_digest=$(docker manifest inspect ${tag}-arm64 | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
+
+            docker manifest create ${tag} ${IMAGE_REGISTRY}/${IMAGE_NAME}@${__amd64_digest} ${IMAGE_REGISTRY}/${IMAGE_NAME}@${__arm64_digest}
+
+            docker manifest push ${tag}
+          done

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -50,16 +50,64 @@ jobs:
             type=ref,event=pr
             type=sha,format=long
 
-      - name: print tags for debugging
+      - name: Print tags for debugging
         run: |
           echo "tags: ${{ steps.meta.outputs.tags }}"
           echo "labels: ${{ steps.meta.outputs.labels }}"
 
-      # - name: Build and push Docker image
-      #   uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
-      #   with:
-      #     context: cloud-v3/
-      #     platforms: linux/amd64,linux/arm64
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
+        with:
+          context: cloud-v3/
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-arm64:
+    runs-on: ubuntu-22.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@40891eba8c2bcd1309b07ba8b11232f313e86779
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e
+        with:
+          images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-arm64
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=long
+
+      - name: Print tags for debugging
+        run: |
+          echo "tags: ${{ steps.meta.outputs.tags }}"
+          echo "labels: ${{ steps.meta.outputs.labels }}"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
+        with:
+          context: cloud-v3/
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -154,7 +154,10 @@ jobs:
 
       - name: Create multi-arch manifests
         run: |
-          for tag in ${{ steps.meta.outputs.tags }}; do
+          tags="${{ steps.meta.outputs.tags }}"
+
+          IFS=$'\n'
+          for tag in $tags; do
             echo "Creating manifest for $tag"
             
             # Combine all manifests into a single manifest

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: macos-latest
+    runs-on: ubuntu-22.04-arm
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-22.04-arm
+    runs-on: macos-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -10,7 +10,7 @@ on:
       - main
       - master
 env:
-  IMAGE_NAME: ${{ github.repository }}-cloud-v3
+  IMAGE_NAME: ${{ github.repository }}/cloud-v3
   IMAGE_REGISTRY: ghcr.io
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ github.token }}

--- a/.github/workflows/cloud-v3-image.yml
+++ b/.github/workflows/cloud-v3-image.yml
@@ -16,7 +16,7 @@ env:
   REGISTRY_PASSWORD: ${{ github.token }}
 
 jobs:
-  build-and-push-image:
+  build-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,6 +41,8 @@ jobs:
         uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e
         with:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-amd64
           tags: |
             type=schedule
             type=ref,event=branch
@@ -48,11 +50,16 @@ jobs:
             type=ref,event=pr
             type=sha,format=long
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
-        with:
-          context: cloud-v3/
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: print tags for debugging
+        run: |
+          echo "tags: ${{ steps.meta.outputs.tags }}"
+          echo "labels: ${{ steps.meta.outputs.labels }}"
+
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
+      #   with:
+      #     context: cloud-v3/
+      #     platforms: linux/amd64,linux/arm64
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds docker image to the registry of this repo. We build amd64 and arm64 images separately on two different types of machines, then combine them in another step. This is much faster compared to multi-arch builds using buildx (<5min vs >40 min).


<img width="2032" alt="image" src="https://github.com/user-attachments/assets/ca972e94-cad6-434f-ae95-6102575baa7b" />

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/b24470b6-cc7a-4a74-b506-118775c1f38f" />
