### PR TITLE
Request persistent storage on the client

### DIFF
--- a/cloud-v3/src/app/layout.tsx
+++ b/cloud-v3/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { Providers } from './providers';
+import ClientInit from '@/components/client-init';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -17,6 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
+        <ClientInit />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/cloud-v3/src/components/client-init.tsx
+++ b/cloud-v3/src/components/client-init.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ClientInit() {
+  useEffect(() => {
+    // Request persistent storage so that cookies and localStorage can have a longer lifetime
+    // https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/persist
+    if (navigator.storage && navigator.storage.persist) {
+      navigator.storage.persist().then((persistent) => {
+        if (persistent) {
+          console.log(
+            "Storage is persistent. Storage will not be cleared except by explicit user action"
+          );
+        } else {
+          console.log(
+            "Storage is NOT persistent. Storage may be cleared by the UA under storage pressure."
+          );
+        }
+      });
+    }
+  }, []);
+
+  return null;
+}

--- a/cloud-v3/src/components/client-init.tsx
+++ b/cloud-v3/src/components/client-init.tsx
@@ -17,6 +17,8 @@ export default function ClientInit() {
             "Storage is NOT persistent. Storage may be cleared by the UA under storage pressure."
           );
         }
+      }).catch((err) => {
+        console.error("Error requesting persistent storage", err);
       });
     }
   }, []);


### PR DESCRIPTION
This PR adds a request for persistent storage for cloud-v3. This make it so that clients can have long-lived localStorage and cookies. This is useful because we want to install the website on users' devices as an app.

This works in Firefox, but not Chrome or Safari. On this page it says Chrome automatically handles this request: https://web.dev/articles/persistent-storage . Perhaps Safari does the same.