### PR TITLE
[codex] restore admin diagnostics panel

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -7,9 +7,11 @@ sudo -E python3 main.py
 ```
 
 Set `GATE_CONTROLLER_AGENT_TOKEN` if the cloud app has `AGENT_TOKEN` configured.
+For Docker Compose, put it in `agent/.env` or export it in the shell before
+starting the service.
 
 Always-on service:
 ```bash
-docker-compose up -d --build
-docker-compose logs --tail 10 -f
+docker compose up -d --build
+docker compose logs --tail 10 -f
 ```

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   agent:
-    container_name: gate_opener_agent
+    container_name: gate_controller_agent
     build: .
+    environment:
+      GATE_CONTROLLER_AGENT_TOKEN: ${GATE_CONTROLLER_AGENT_TOKEN:-}
     volumes:
       - ./:/workspace
       - /dev/mem:/dev/mem

--- a/agent/main.py
+++ b/agent/main.py
@@ -16,7 +16,7 @@ sentry_logging = LoggingIntegration(
     event_level=logging.ERROR  # Send errors as events
 )
 sentry_sdk.init(
-    # Obtained from https://unicorns-are-cool.sentry.io/settings/projects/gate-opener/keys/
+    # Gate controller agent Sentry project DSN.
     dsn="https://b3184994f9d267983dc3a5c99747b8b0@o4505847402135552.ingest.sentry.io/4505847409410048",
     integrations=[
         sentry_logging,
@@ -79,7 +79,7 @@ def loop_once():
         logging.info("Sleeping for 2 seconds and trying again")
         time.sleep(2)
 
-@monitor(monitor_slug='gate-opener-agent')
+@monitor(monitor_slug='gate-controller-agent')
 def ping_healthcheck():
     sleep(0.5) # space out the begin and end API calls
 

--- a/cloud-v3/playwright.config.ts
+++ b/cloud-v3/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@playwright/test";
 const port = Number(process.env.PORT ?? 3100);
 
 export default defineConfig({
-  testDir: "./tests/e2e",
+  testDir: "./tests",
   fullyParallel: false,
   workers: 1,
   timeout: 45_000,

--- a/cloud-v3/src/app/api/schedules/route.ts
+++ b/cloud-v3/src/app/api/schedules/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import {
   createSchedule,
   deleteSchedule,
+  getSchedule,
   getSchedules,
   updateSchedule as saveSchedule,
 } from '@/lib/db';
@@ -47,6 +48,10 @@ export async function POST(request: NextRequest) {
       throw new ApiError(400, 'Invalid cron expression');
     }
 
+    if (getSchedule(name)) {
+      throw new ApiError(400, `Schedule already exists: ${name}`);
+    }
+
     const newSchedule = createSchedule({
       name,
       cron_expression,
@@ -74,6 +79,9 @@ export async function PUT(request: NextRequest) {
 
     if (!name) {
       throw new ApiError(400, 'Missing schedule name');
+    }
+    if (!getSchedule(name)) {
+      throw new ApiError(400, `Schedule not found: ${name}`);
     }
 
     const body = requireObject(await readJsonBody(request));
@@ -110,6 +118,9 @@ export async function DELETE(request: NextRequest) {
 
     if (!name) {
       throw new ApiError(400, 'Missing schedule name');
+    }
+    if (!getSchedule(name)) {
+      throw new ApiError(400, `Schedule not found: ${name}`);
     }
 
     await stopSchedule(name);

--- a/cloud-v3/src/app/api/users/route.ts
+++ b/cloud-v3/src/app/api/users/route.ts
@@ -30,6 +30,10 @@ export async function POST(request: NextRequest) {
     const password = requireString(body, 'password');
     const role = requireRole(body.role);
 
+    if (getUsers().some((existing) => existing.username === username)) {
+      throw new ApiError(400, `User already exists: ${username}`);
+    }
+
     const newUser = createUser({
       username,
       password,
@@ -50,6 +54,10 @@ export async function PUT(request: NextRequest) {
     const username = requireString(body, 'username');
     const password = optionalString(body, 'password');
     const role = body.role === undefined ? undefined : requireRole(body.role);
+
+    if (!getUsers().some((existing) => existing.username === username)) {
+      throw new ApiError(400, `User not found: ${username}`);
+    }
 
     updateUser({
       username,

--- a/cloud-v3/src/app/dashboard/page.tsx
+++ b/cloud-v3/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { ensureSession } from "@/lib/auth/ensure-session";
 import { GateController } from "@/components/gate-controller";
 import { ScheduleManager } from "@/components/schedule-manager";
 import { UserManagement } from "@/components/user-management";
+import { DiagnosticsPanel } from "@/components/diagnostics-panel";
 import { getInitialData } from "@/lib/data";
 import { SWRConfig } from "swr";
 
@@ -51,9 +52,15 @@ export default async function DashboardPage() {
 
             {/* User Management Section (Admin only) */}
             {user.role === 'admin' && (
-              <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
-                <UserManagement />
-              </section>
+              <>
+                <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
+                  <UserManagement />
+                </section>
+
+                <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
+                  <DiagnosticsPanel />
+                </section>
+              </>
             )}
 
             {/* Logout Button */}

--- a/cloud-v3/src/components/browser-diagnostics.tsx
+++ b/cloud-v3/src/components/browser-diagnostics.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { DiagnosticGrid } from './diagnostic-grid';
+
+type StorageState = {
+  persistent?: boolean;
+  quota?: number;
+  usage?: number;
+  error?: string;
+};
+
+export function BrowserDiagnostics() {
+  const [storage, setStorage] = useState<StorageState>({});
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadStorageState() {
+      try {
+        const [persistent, estimate] = await Promise.all([
+          navigator.storage?.persisted?.() ?? false,
+          navigator.storage?.estimate?.() ?? {},
+        ]);
+
+        if (!cancelled) {
+          setStorage({
+            persistent,
+            quota: estimate.quota,
+            usage: estimate.usage,
+          });
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setStorage({
+            error: error instanceof Error ? error.message : 'Unavailable',
+          });
+        }
+      }
+    }
+
+    loadStorageState();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const storageDiagnostics = [
+    ['Persistent storage', storage.error ?? formatBoolean(storage.persistent)],
+    ['Storage usage', `${formatBytes(storage.usage)} / ${formatBytes(storage.quota)}`],
+  ] as const;
+
+  return <DiagnosticGrid items={storageDiagnostics} />;
+}
+
+function formatBoolean(value: boolean | undefined) {
+  if (value === undefined) return 'checking';
+  return value ? 'enabled' : 'disabled';
+}
+
+function formatBytes(value: number | undefined) {
+  if (value === undefined) return 'unknown';
+  if (value < 1024) return `${value} B`;
+
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let amount = value / 1024;
+  let unitIndex = 0;
+
+  while (amount >= 1024 && unitIndex < units.length - 1) {
+    amount /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${amount.toFixed(1)} ${units[unitIndex]}`;
+}

--- a/cloud-v3/src/components/diagnostic-grid.tsx
+++ b/cloud-v3/src/components/diagnostic-grid.tsx
@@ -1,0 +1,21 @@
+type DiagnosticItem = readonly [label: string, value: string];
+
+export function DiagnosticGrid({ items }: { items: readonly DiagnosticItem[] }) {
+  return (
+    <dl className="grid gap-3 text-sm sm:grid-cols-2">
+      {items.map(([label, value]) => (
+        <div
+          key={label}
+          className="border-t border-gray-200 pt-3 dark:border-gray-700"
+        >
+          <dt className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+            {label}
+          </dt>
+          <dd className="mt-1 font-mono text-gray-900 dark:text-gray-100">
+            {value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/cloud-v3/src/components/diagnostics-panel.tsx
+++ b/cloud-v3/src/components/diagnostics-panel.tsx
@@ -1,0 +1,52 @@
+import { config, secrets } from "@/config";
+import { BrowserDiagnostics } from "./browser-diagnostics";
+import { DiagnosticGrid } from "./diagnostic-grid";
+
+const serverDiagnostics = [
+  ["Controller timezone", config.controllerTimezone],
+  ["Database path", config.dbPath],
+  ["Redis", `${config.redis.host}:${config.redis.port}`],
+  ["Agent auth", secrets.agentToken ? "required" : "not required"],
+  ["Node environment", process.env.NODE_ENV || "development"],
+] as const;
+
+export function DiagnosticsPanel() {
+  return (
+    <details className="group">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-4">
+        <h2 className="text-xl font-semibold">Diagnostics</h2>
+        <span className="text-sm text-gray-500 group-open:hidden dark:text-gray-400">
+          Show
+        </span>
+        <span className="hidden text-sm text-gray-500 group-open:inline dark:text-gray-400">
+          Hide
+        </span>
+      </summary>
+
+      <div className="mt-6 space-y-6">
+        <div>
+          <h3 className="mb-3 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+            Server
+          </h3>
+          <DiagnosticGrid items={serverDiagnostics} />
+        </div>
+
+        <div>
+          <h3 className="mb-3 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+            Browser
+          </h3>
+          <BrowserDiagnostics />
+        </div>
+
+        <div>
+          <h3 className="mb-3 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+            Build
+          </h3>
+          <pre className="max-h-64 overflow-auto rounded-lg bg-gray-50 p-3 text-xs text-gray-900 dark:bg-gray-900/60 dark:text-gray-100">
+            {JSON.stringify(config.buildInfo, null, 2)}
+          </pre>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cloud-v3/src/components/gate-controller.tsx
+++ b/cloud-v3/src/components/gate-controller.tsx
@@ -113,9 +113,41 @@ export function GateController() {
 
       {gateStatus.history && (
         <div>
-          <h3 className="text-lg font-medium mb-3">Recent Activity</h3>
-          <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg overflow-hidden">
-            <div className="max-h-[300px] overflow-y-auto">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h3 className="text-lg font-medium">Recent Activity</h3>
+            <select
+              value={timeFormat}
+              onChange={(e) => handleTimeFormatChange(e.target.value as TimeFormat)}
+              className="rounded border border-gray-200 bg-transparent px-2 py-1 text-xs hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700 sm:hidden"
+              title={`Select time format (Controller timezone: ${publicConfig.controllerTimezone})`}
+            >
+              <option value="relative">Relative</option>
+              <option value="controller">Controller</option>
+            </select>
+          </div>
+          <div className="rounded-lg bg-gray-50 dark:bg-gray-800/50">
+            <div className="space-y-3 p-4 sm:hidden">
+              {gateStatus.history.map((entry, index) => (
+                <div
+                  key={index}
+                  className="rounded-lg bg-white p-3 text-sm dark:bg-gray-800"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <ActionBadge action={entry.action} />
+                    <TimeDisplay
+                      timestamp={entry.timestamp}
+                      format={timeFormat === 'relative' ? 'relative' : publicConfig.controllerTimezone}
+                      className="text-sm text-gray-600 dark:text-gray-400"
+                    />
+                  </div>
+                  <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                    {entry.actor}{entry.actor_name ? `: ${entry.actor_name}` : ''}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="hidden max-h-[300px] overflow-y-auto sm:block">
               <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                 <thead className="bg-gray-100 dark:bg-gray-800 sticky top-0">
                   <tr>
@@ -142,13 +174,7 @@ export function GateController() {
                   {gateStatus.history.map((entry, index) => (
                     <tr key={index} className="hover:bg-gray-100 dark:hover:bg-gray-800/50">
                       <td className="px-4 py-2 whitespace-nowrap">
-                        <span className={`px-2 py-1 text-xs font-medium rounded-full ${
-                          entry.action === 'open'
-                            ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
-                            : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                        }`}>
-                          {entry.action}
-                        </span>
+                        <ActionBadge action={entry.action} />
                       </td>
                       <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
                         <TimeDisplay
@@ -171,5 +197,19 @@ export function GateController() {
         </div>
       )}
     </div>
+  );
+}
+
+function ActionBadge({ action }: { action: 'open' | 'close' }) {
+  return (
+    <span
+      className={`px-2 py-1 text-xs font-medium rounded-full ${
+        action === 'open'
+          ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+          : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+      }`}
+    >
+      {action}
+    </span>
   );
 }

--- a/cloud-v3/src/components/schedule-manager.tsx
+++ b/cloud-v3/src/components/schedule-manager.tsx
@@ -227,72 +227,107 @@ export function ScheduleManager() {
         )}
 
         {schedules && schedules.length > 0 ? (
-          <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <thead className="bg-gray-100 dark:bg-gray-800">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Schedule
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Cron Expression
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Action
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white dark:bg-transparent divide-y divide-gray-200 dark:divide-gray-700">
-                {schedules.map((schedule) => (
-                  <tr key={schedule.name}>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      {schedule.name}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      <div>{schedule.cron_expression}</div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
-                        {getCronDescription(schedule.cron_expression)}
+          <>
+            <div className="space-y-3 sm:hidden">
+              {schedules.map((schedule) => (
+                <div
+                  key={schedule.name}
+                  className="rounded-lg bg-gray-50 p-4 text-sm dark:bg-gray-800/50"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="font-medium">{schedule.name}</div>
+                      <div className="mt-1 font-mono text-xs text-gray-600 dark:text-gray-400">
+                        {schedule.cron_expression}
                       </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      {schedule.action}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                          schedule.enabled
-                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200'
-                            : 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-200'
-                        }`}
-                      >
-                        {schedule.enabled ? 'Enabled' : 'Disabled'}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
+                    </div>
+                    <ScheduleStatus enabled={schedule.enabled} />
+                  </div>
+                  <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+                    {getCronDescription(schedule.cron_expression)}
+                  </div>
+                  <div className="mt-3 flex items-center justify-between gap-3">
+                    <span className="text-gray-600 dark:text-gray-400">
+                      Action: <span className="font-medium text-gray-900 dark:text-gray-100">{schedule.action}</span>
+                    </span>
+                    <div className="shrink-0 text-sm">
                       <button
                         onClick={() => handleEdit(schedule)}
-                        className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 mr-3"
+                        className="mr-3 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
                       >
                         Edit
                       </button>
                       <button
                         onClick={() => handleDelete(schedule.name)}
-                        className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
+                        className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
                       >
                         Delete
                       </button>
-                    </td>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="hidden overflow-x-auto rounded-lg bg-gray-50 dark:bg-gray-800/50 sm:block">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-100 dark:bg-gray-800">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Schedule
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Cron Expression
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Action
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Status
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Actions
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody className="bg-white dark:bg-transparent divide-y divide-gray-200 dark:divide-gray-700">
+                  {schedules.map((schedule) => (
+                    <tr key={schedule.name}>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                        {schedule.name}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                        <div>{schedule.cron_expression}</div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400">
+                          {getCronDescription(schedule.cron_expression)}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                        {schedule.action}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                        <ScheduleStatus enabled={schedule.enabled} />
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
+                        <button
+                          onClick={() => handleEdit(schedule)}
+                          className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 mr-3"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => handleDelete(schedule.name)}
+                          className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         ) : (
           <div className="text-center py-12 text-gray-500 dark:text-gray-400">
             No schedules found. Click &quot;Add Schedule&quot; to create one.
@@ -300,5 +335,19 @@ export function ScheduleManager() {
         )}
       </div>
     </div>
+  );
+}
+
+function ScheduleStatus({ enabled }: { enabled: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        enabled
+          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200'
+          : 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-200'
+      }`}
+    >
+      {enabled ? 'Enabled' : 'Disabled'}
+    </span>
   );
 }

--- a/cloud-v3/src/components/user-management.tsx
+++ b/cloud-v3/src/components/user-management.tsx
@@ -186,68 +186,109 @@ export function UserManagement() {
       )}
 
       {users && users.length > 0 ? (
-        <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-100 dark:bg-gray-800">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Username
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Role
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Created At
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white dark:bg-transparent divide-y divide-gray-200 dark:divide-gray-700">
-              {users.map((user) => (
-                <tr key={user.username}>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">
-                    {user.username}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                        user.role === 'admin'
-                          ? 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-200'
-                          : 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200'
-                      }`}
-                    >
-                      {user.role}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
-                    {formatInTimeZone(user.created_at, publicConfig.controllerTimezone, 'yyyy-MM-dd HH:mm:ss zzz')}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
-                    <button
-                      onClick={() => handleEdit(user)}
-                      className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 mr-3"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      onClick={() => handleDelete(user.username)}
-                      className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
-                    >
-                      Delete
-                    </button>
-                  </td>
+        <>
+          <div className="space-y-3 sm:hidden">
+            {users.map((user) => (
+              <div
+                key={user.username}
+                className="rounded-lg bg-gray-50 p-4 text-sm dark:bg-gray-800/50"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="font-medium">{user.username}</div>
+                    <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      {formatInTimeZone(user.created_at, publicConfig.controllerTimezone, 'yyyy-MM-dd HH:mm:ss zzz')}
+                    </div>
+                  </div>
+                  <RoleBadge role={user.role} />
+                </div>
+                <div className="mt-3 flex justify-end text-sm">
+                  <button
+                    onClick={() => handleEdit(user)}
+                    className="mr-3 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDelete(user.username)}
+                    className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="hidden overflow-x-auto rounded-lg bg-gray-50 dark:bg-gray-800/50 sm:block">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-100 dark:bg-gray-800">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Username
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Role
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Created At
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Actions
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="bg-white dark:bg-transparent divide-y divide-gray-200 dark:divide-gray-700">
+                {users.map((user) => (
+                  <tr key={user.username}>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm">
+                      {user.username}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm">
+                      <RoleBadge role={user.role} />
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
+                      {formatInTimeZone(user.created_at, publicConfig.controllerTimezone, 'yyyy-MM-dd HH:mm:ss zzz')}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
+                      <button
+                        onClick={() => handleEdit(user)}
+                        className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 mr-3"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleDelete(user.username)}
+                        className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       ) : (
         <div className="text-center py-12 text-gray-500 dark:text-gray-400">
           No users found. Click &quot;Add User&quot; to create one.
         </div>
       )}
     </div>
+  );
+}
+
+function RoleBadge({ role }: { role: User['role'] }) {
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        role === 'admin'
+          ? 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-200'
+          : 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200'
+      }`}
+    >
+      {role}
+    </span>
   );
 }

--- a/cloud-v3/tests/e2e/gate-controller.spec.ts
+++ b/cloud-v3/tests/e2e/gate-controller.spec.ts
@@ -1,49 +1,11 @@
-import { expect, test, type Page } from "@playwright/test";
-
-const admin = { username: "admin", password: "password" };
-const agentToken = process.env.AGENT_TOKEN ?? "e2e-agent-token";
-
-async function login(page: Page, username: string, password: string) {
-  await page.goto("/login");
-  await page.getByLabel("Username").fill(username);
-  await page.getByLabel("Password").fill(password);
-  await page.getByRole("button", { name: "Sign in" }).click();
-  await expect(page).toHaveURL(/\/dashboard$/);
-}
-
-async function browserJson(
-  page: Page,
-  url: string,
-  options: { body?: unknown; method?: string } = {}
-): Promise<{ status: number; body: unknown }> {
-  return page.evaluate(
-    async ({ requestUrl, body, method }) => {
-      const response = await fetch(requestUrl, {
-        body: body === undefined ? undefined : JSON.stringify(body),
-        headers: body === undefined ? undefined : { "content-type": "application/json" },
-        method,
-      });
-      let responseBody: unknown = null;
-      try {
-        responseBody = await response.json();
-      } catch {
-        // 204 responses have no body.
-      }
-      return { status: response.status, body: responseBody };
-    },
-    { requestUrl: url, body: options.body, method: options.method ?? "GET" }
-  );
-}
-
-async function expectNoHorizontalOverflow(page: Page) {
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
-      )
-    )
-    .toBe(true);
-}
+import { expect, test } from "@playwright/test";
+import {
+  admin,
+  agentToken,
+  browserJson,
+  expectNoHorizontalOverflow,
+  login,
+} from "../helpers";
 
 test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await expect((await request.get("/api/gate")).status()).toBe(401);
@@ -86,24 +48,6 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await page.getByLabel("Action").selectOption("open");
   await page.getByRole("button", { name: "Create Schedule" }).click();
   await expect(page.getByRole("cell", { name: scheduleName })).toBeVisible();
-  expect(
-    await browserJson(page, "/api/schedules", {
-      body: {
-        action: "open",
-        cron_expression: "0 8 * * 1-5",
-        enabled: true,
-        name: scheduleName,
-      },
-      method: "POST",
-    })
-  ).toEqual({
-    status: 400,
-    body: { error: `Schedule already exists: ${scheduleName}` },
-  });
-  expect(await browserJson(page, "/api/schedules?name=missing", { method: "DELETE" })).toEqual({
-    status: 400,
-    body: { error: "Schedule not found: missing" },
-  });
 
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(page.getByText("Action: open")).toBeVisible();
@@ -127,24 +71,6 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await page.getByLabel("Role").selectOption("user");
   await page.getByRole("button", { name: "Create User" }).click();
   await expect(page.getByRole("cell", { name: username })).toBeVisible();
-  expect(
-    await browserJson(page, "/api/users", {
-      body: { password, role: "user", username },
-      method: "POST",
-    })
-  ).toEqual({
-    status: 400,
-    body: { error: `User already exists: ${username}` },
-  });
-  expect(
-    await browserJson(page, "/api/users", {
-      body: { role: "user", username: "missing" },
-      method: "PUT",
-    })
-  ).toEqual({
-    status: 400,
-    body: { error: "User not found: missing" },
-  });
 
   const userContext = await browser.newContext();
   const userPage = await userContext.newPage();

--- a/cloud-v3/tests/e2e/gate-controller.spec.ts
+++ b/cloud-v3/tests/e2e/gate-controller.spec.ts
@@ -14,20 +14,24 @@ async function login(page: Page, username: string, password: string) {
 async function browserJson(
   page: Page,
   url: string,
-  options: { method?: string } = {}
+  options: { body?: unknown; method?: string } = {}
 ): Promise<{ status: number; body: unknown }> {
   return page.evaluate(
-    async ({ requestUrl, method }) => {
-      const response = await fetch(requestUrl, { method });
-      let body: unknown = null;
+    async ({ requestUrl, body, method }) => {
+      const response = await fetch(requestUrl, {
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers: body === undefined ? undefined : { "content-type": "application/json" },
+        method,
+      });
+      let responseBody: unknown = null;
       try {
-        body = await response.json();
+        responseBody = await response.json();
       } catch {
         // 204 responses have no body.
       }
-      return { status: response.status, body };
+      return { status: response.status, body: responseBody };
     },
-    { requestUrl: url, method: options.method ?? "GET" }
+    { requestUrl: url, body: options.body, method: options.method ?? "GET" }
   );
 }
 
@@ -82,6 +86,24 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await page.getByLabel("Action").selectOption("open");
   await page.getByRole("button", { name: "Create Schedule" }).click();
   await expect(page.getByRole("cell", { name: scheduleName })).toBeVisible();
+  expect(
+    await browserJson(page, "/api/schedules", {
+      body: {
+        action: "open",
+        cron_expression: "0 8 * * 1-5",
+        enabled: true,
+        name: scheduleName,
+      },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `Schedule already exists: ${scheduleName}` },
+  });
+  expect(await browserJson(page, "/api/schedules?name=missing", { method: "DELETE" })).toEqual({
+    status: 400,
+    body: { error: "Schedule not found: missing" },
+  });
 
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(page.getByText("Action: open")).toBeVisible();
@@ -105,6 +127,24 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await page.getByLabel("Role").selectOption("user");
   await page.getByRole("button", { name: "Create User" }).click();
   await expect(page.getByRole("cell", { name: username })).toBeVisible();
+  expect(
+    await browserJson(page, "/api/users", {
+      body: { password, role: "user", username },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `User already exists: ${username}` },
+  });
+  expect(
+    await browserJson(page, "/api/users", {
+      body: { role: "user", username: "missing" },
+      method: "PUT",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: "User not found: missing" },
+  });
 
   const userContext = await browser.newContext();
   const userPage = await userContext.newPage();

--- a/cloud-v3/tests/e2e/gate-controller.spec.ts
+++ b/cloud-v3/tests/e2e/gate-controller.spec.ts
@@ -31,6 +31,16 @@ async function browserJson(
   );
 }
 
+async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
+      )
+    )
+    .toBe(true);
+}
+
 test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await expect((await request.get("/api/gate")).status()).toBe(401);
   await expect((await request.get("/api/schedules/upcoming")).status()).toBe(401);
@@ -72,6 +82,11 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await page.getByLabel("Action").selectOption("open");
   await page.getByRole("button", { name: "Create Schedule" }).click();
   await expect(page.getByRole("cell", { name: scheduleName })).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.getByText("Action: open")).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+  await page.setViewportSize({ width: 1280, height: 720 });
 
   await expect
     .poll(async () => {

--- a/cloud-v3/tests/e2e/gate-controller.spec.ts
+++ b/cloud-v3/tests/e2e/gate-controller.spec.ts
@@ -48,6 +48,10 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await login(page, admin.username, admin.password);
 
   await expect(page.getByRole("heading", { name: "Gate Controller" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Diagnostics" })).toBeVisible();
+  await page.getByText("Show").click();
+  await expect(page.getByText("Controller timezone")).toBeVisible();
+  await expect(page.getByText("Agent auth")).toBeVisible();
   await expect(page.getByText("CLOSED")).toBeVisible();
 
   await page.getByRole("button", { name: "Open Gate" }).click();
@@ -91,6 +95,7 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   const userPage = await userContext.newPage();
   await login(userPage, username, password);
   await expect(userPage.getByRole("heading", { name: "User Management" })).toHaveCount(0);
+  await expect(userPage.getByRole("heading", { name: "Diagnostics" })).toHaveCount(0);
   await expect((await browserJson(userPage, "/api/users")).status).toBe(403);
   await userContext.close();
 

--- a/cloud-v3/tests/helpers.ts
+++ b/cloud-v3/tests/helpers.ts
@@ -1,0 +1,46 @@
+import { expect, type Page } from "@playwright/test";
+
+export const admin = { username: "admin", password: "password" };
+export const agentToken = process.env.AGENT_TOKEN ?? "e2e-agent-token";
+
+export async function login(page: Page, username: string, password: string) {
+  await page.goto("/login");
+  await page.getByLabel("Username").fill(username);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page).toHaveURL(/\/dashboard$/);
+}
+
+export async function browserJson(
+  page: Page,
+  url: string,
+  options: { body?: unknown; method?: string } = {}
+): Promise<{ status: number; body: unknown }> {
+  return page.evaluate(
+    async ({ requestUrl, body, method }) => {
+      const response = await fetch(requestUrl, {
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers: body === undefined ? undefined : { "content-type": "application/json" },
+        method,
+      });
+      let responseBody: unknown = null;
+      try {
+        responseBody = await response.json();
+      } catch {
+        // 204 responses have no body.
+      }
+      return { status: response.status, body: responseBody };
+    },
+    { requestUrl: url, body: options.body, method: options.method ?? "GET" }
+  );
+}
+
+export async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
+      )
+    )
+    .toBe(true);
+}

--- a/cloud-v3/tests/integration/api-routes.spec.ts
+++ b/cloud-v3/tests/integration/api-routes.spec.ts
@@ -1,0 +1,219 @@
+import { expect, test } from "@playwright/test";
+import { admin, agentToken, browserJson, login } from "../helpers";
+
+test("api routes enforce auth and controlled edge errors", async ({
+  browser,
+  page,
+  request,
+}) => {
+  const suffix = Date.now().toString(36);
+  const scheduleName = `api schedule ${suffix}`;
+  const username = `api-user-${suffix}`;
+  const password = "api-password";
+
+  for (const { method, url } of [
+    { method: "GET", url: "/api/gate" },
+    { method: "GET", url: "/api/gate?history=true" },
+    { method: "POST", url: "/api/gate" },
+    { method: "GET", url: "/api/schedules" },
+    { method: "GET", url: "/api/schedules/upcoming" },
+    { method: "POST", url: "/api/schedules" },
+    { method: "GET", url: "/api/users" },
+  ]) {
+    const response =
+      method === "GET"
+        ? await request.get(url)
+        : await request.post(url, { data: { action: "open" } });
+    expect(response.status(), `${method} ${url}`).toBe(401);
+  }
+
+  await expect((await request.post("/api/gate/take_status")).status()).toBe(401);
+  await expect(
+    (
+      await request.post("/api/gate/take_status", {
+        headers: { Authorization: "Bearer wrong" },
+      })
+    ).status()
+  ).toBe(401);
+
+  const agentStatus = await request.post("/api/gate/take_status", {
+    headers: { Authorization: `Bearer ${agentToken}` },
+  });
+  await expect(agentStatus).toBeOK();
+  const agentStatusBody = await agentStatus.json();
+  expect(["closed", "open"]).toContain(agentStatusBody.status);
+  expect(agentStatusBody.lastContactTimestamp).toBeGreaterThan(0);
+
+  await login(page, admin.username, admin.password);
+
+  expect(
+    await browserJson(page, "/api/schedules", {
+      body: {
+        action: "open",
+        cron_expression: "0 6 * * *",
+        enabled: true,
+        name: scheduleName,
+      },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 200,
+    body: {
+      action: "open",
+      created_by: admin.username,
+      cron_expression: "0 6 * * *",
+      enabled: true,
+      name: scheduleName,
+    },
+  });
+  expect(
+    await browserJson(page, "/api/schedules", {
+      body: {
+        action: "open",
+        cron_expression: "0 6 * * *",
+        enabled: true,
+        name: scheduleName,
+      },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `Schedule already exists: ${scheduleName}` },
+  });
+  expect(
+    await browserJson(page, "/api/schedules", {
+      body: {
+        action: "open",
+        cron_expression: "not cron",
+        enabled: true,
+        name: `bad-cron-${suffix}`,
+      },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: "Invalid cron expression" },
+  });
+  expect(
+    await browserJson(page, "/api/schedules", {
+      body: {
+        action: "raise",
+        cron_expression: "0 6 * * *",
+        enabled: true,
+        name: `bad-action-${suffix}`,
+      },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: "Invalid action" },
+  });
+  expect(
+    await browserJson(page, `/api/schedules?name=missing-${suffix}`, {
+      body: { enabled: false },
+      method: "PUT",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `Schedule not found: missing-${suffix}` },
+  });
+  expect(
+    await browserJson(page, `/api/schedules?name=missing-${suffix}`, {
+      method: "DELETE",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `Schedule not found: missing-${suffix}` },
+  });
+  expect(
+    await browserJson(page, "/api/gate", {
+      body: { action: "raise" },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: "Invalid action" },
+  });
+
+  expect(
+    await browserJson(page, "/api/users", {
+      body: { password, role: "user", username },
+      method: "POST",
+    })
+  ).toMatchObject({
+    status: 200,
+    body: { created_by: admin.username, role: "user", username },
+  });
+  expect(
+    await browserJson(page, "/api/users", {
+      body: { password, role: "user", username },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `User already exists: ${username}` },
+  });
+  expect(
+    await browserJson(page, "/api/users", {
+      body: { password, role: "owner", username: `bad-role-${suffix}` },
+      method: "POST",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: "Invalid role" },
+  });
+  expect(
+    await browserJson(page, "/api/users", {
+      body: { role: "user", username: `missing-${suffix}` },
+      method: "PUT",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `User not found: missing-${suffix}` },
+  });
+  expect(
+    await browserJson(page, `/api/users?username=missing-${suffix}`, {
+      method: "DELETE",
+    })
+  ).toEqual({
+    status: 400,
+    body: { error: `User not found: missing-${suffix}` },
+  });
+
+  const userContext = await browser.newContext();
+  const userPage = await userContext.newPage();
+  await login(userPage, username, password);
+
+  await expect(userPage.getByRole("heading", { name: "Diagnostics" })).toHaveCount(0);
+  await expect(userPage.getByRole("heading", { name: "User Management" })).toHaveCount(0);
+  expect(await browserJson(userPage, "/api/users")).toEqual({
+    status: 403,
+    body: { error: "Forbidden" },
+  });
+  const userSchedules = await browserJson(userPage, "/api/schedules");
+  expect(userSchedules.status).toBe(200);
+  expect(userSchedules.body).toEqual(
+    expect.arrayContaining([expect.objectContaining({ name: scheduleName })])
+  );
+  expect(
+    await browserJson(userPage, "/api/gate", {
+      body: { action: "close" },
+      method: "POST",
+    })
+  ).toMatchObject({
+    status: 200,
+    body: { status: "close" },
+  });
+  await userContext.close();
+
+  expect(
+    await browserJson(page, `/api/users?username=${encodeURIComponent(username)}`, {
+      method: "DELETE",
+    })
+  ).toEqual({ status: 204, body: null });
+  expect(
+    await browserJson(page, `/api/schedules?name=${encodeURIComponent(scheduleName)}`, {
+      method: "DELETE",
+    })
+  ).toEqual({ status: 204, body: null });
+});


### PR DESCRIPTION
## Summary

- Restore an admin-only Diagnostics panel on the cloud-v3 dashboard.
- Show server/runtime details, browser storage state, and build metadata in a collapsed panel.
- Avoid exposing secret values: agent auth is shown only as `required` / `not required`.
- Add a tiny shared `DiagnosticGrid` from the code-simplifier pass so server and browser diagnostics use the same markup.
- Improve mobile dashboard layout for Recent Activity, Schedule Manager, and User Management by rendering compact cards instead of clipped horizontal tables on small screens.
- Harden schedule/user API edge cases so duplicate and not-found cases return controlled 400 responses instead of leaking through as 500s.
- Add dedicated request-level integration coverage for the API/auth/edge-case matrix, separate from the UI E2E workflow.

## Review notes

- The diagnostics panel is rendered only for `admin` users, beside User Management.
- Regular users do not see User Management or Diagnostics.
- Browser diagnostics read storage state once; they do not request persistence or poll.
- Desktop tables remain in place; mobile uses card layouts for the dense admin/data sections.
- Playwright now runs both `tests/e2e` and `tests/integration` against the same production Next server, Redis, and SQLite setup.

## Screenshots

Generated with Playwright against a local review server after the production build:

- Desktop schedule form: `/tmp/gate-controller-pr-screenshots/desktop-schedule-form.png`
- Desktop schedule created: `/tmp/gate-controller-pr-screenshots/desktop-schedule-created.png`
- Desktop schedule edited: `/tmp/gate-controller-pr-screenshots/desktop-schedule-edited.png`
- Desktop diagnostics after schedule CRUD: `/tmp/gate-controller-pr-screenshots/desktop-diagnostics-after-schedule-crud.png`
- Mobile admin dashboard: `/tmp/gate-controller-pr-screenshots/mobile-admin-dashboard-empty.png`
- Mobile schedule form: `/tmp/gate-controller-pr-screenshots/mobile-schedule-form.png`
- Mobile schedule created: `/tmp/gate-controller-pr-screenshots/mobile-schedule-created.png`
- Mobile diagnostics open: `/tmp/gate-controller-pr-screenshots/mobile-diagnostics-open.png`
- Mobile regular user dashboard: `/tmp/gate-controller-pr-screenshots/mobile-user-no-admin-panels.png`

I did not commit these PNGs to avoid adding transient binary review artifacts to the repo.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run e2e` now runs:
  - UI E2E workflow
  - API integration spec against production server/auth/DB
- `git diff --check`
- Integration matrix covers:
  - anonymous API endpoints return 401
  - agent endpoint rejects missing/wrong token and accepts the configured token
  - invalid gate/schedule/user inputs return 400
  - duplicate schedule/user returns 400
  - missing schedule update/delete and missing user update/delete return 400
  - regular users cannot access admin-only users API or panels
- Manual/visual Playwright click-through:
  - desktop schedule create/edit/delete
  - invalid cron form feedback and cancel
  - admin Diagnostics open
  - mobile schedule creation
  - mobile Diagnostics open
  - mobile regular-user dashboard without admin panels
  - checked no document-level horizontal overflow or offscreen controls at `390x844`
  - checked no browser console errors or page errors during smoke pass
