### PR TITLE
[codex] add agent dry-run mode

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -10,6 +10,12 @@ Set `GATE_CONTROLLER_AGENT_TOKEN` to match the cloud app's `AGENT_TOKEN`.
 For Docker Compose, put it in `agent/.env` or export it in the shell before
 starting the service. Compose fails fast if the variable is missing.
 
+Set `GATE_CONTROLLER_AGENT_DRY_RUN=1` to poll the cloud service and log the
+relay actions without importing, initializing, writing, or cleaning up GPIO.
+This is useful for validating token and cloud connectivity without toggling the
+gate. Dry-run polls the cloud service normally, so the last-contact timestamp
+updates, but it does not initialize Sentry monitoring.
+
 Always-on service:
 ```bash
 docker compose up -d --build

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     environment:
       GATE_CONTROLLER_AGENT_TOKEN: "${GATE_CONTROLLER_AGENT_TOKEN:?set GATE_CONTROLLER_AGENT_TOKEN}"
+      GATE_CONTROLLER_AGENT_DRY_RUN: ${GATE_CONTROLLER_AGENT_DRY_RUN:-}
     volumes:
       - ./:/workspace
       - /dev/mem:/dev/mem

--- a/agent/main.py
+++ b/agent/main.py
@@ -1,106 +1,197 @@
 import requests
-import RPi.GPIO as GPIO
 import time
-import sys
 import socket
 import logging
 import os
-import sentry_sdk
-from sentry_sdk.crons import monitor
-from sentry_sdk.integrations.logging import LoggingIntegration
-from time import sleep, perf_counter
 
-# All of this is already happening by default!
-sentry_logging = LoggingIntegration(
-    level=logging.INFO,        # Capture info and above as breadcrumbs
-    event_level=logging.ERROR  # Send errors as events
-)
-sentry_sdk.init(
-    # Gate controller agent Sentry project DSN.
-    dsn="https://b3184994f9d267983dc3a5c99747b8b0@o4505847402135552.ingest.sentry.io/4505847409410048",
-    integrations=[
-        sentry_logging,
-    ],
+DRY_RUN_ENV = "GATE_CONTROLLER_AGENT_DRY_RUN"
+AGENT_TOKEN_ENV = "GATE_CONTROLLER_AGENT_TOKEN"
+GATE_STATUS_URL = "https://gate-controller-cloud-v3.benzhang.dev/api/gate/take_status"
+MONITOR_SLUG = "gate-controller-agent"
+RELAY_PIN = 4
+TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+FALSE_VALUES = {"", "0", "false", "f", "no", "n", "off"}
 
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production.
-    traces_sample_rate=1.0
-)
 
-logging.basicConfig(level=logging.INFO)
+def env_flag(name):
+    value = os.environ.get(name, "")
+    normalized = value.strip().lower()
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+    raise ValueError(
+        f"{name} must be one of {sorted(TRUE_VALUES | FALSE_VALUES)}, got {value!r}"
+    )
 
-hostname = socket.gethostname()
 
-# Define GPIO pin numbers
-relay1 = 4
-# kept for future use
-# relay2 = 22
-# relay3 = 6
-# relay4 = 26
-
-# Use the Broadcom SOC channel
-GPIO.setmode(GPIO.BCM)
-
-## Set up GPIO pins
-GPIO.setup(relay1, GPIO.OUT)
-
-logging.info("Initializing relay to off")
-GPIO.output(relay1, GPIO.LOW)
-
-def loop_once():
+def init_sentry():
     try:
-        # url = 'http://100.106.129.114:8081/api/take_command' # for debugging
-        url = "https://gate-controller-cloud-v3.benzhang.dev/api/gate/take_status"
-        data = {'host': hostname}
-        headers = {}
-        token = os.environ.get("GATE_CONTROLLER_AGENT_TOKEN")
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
+        import sentry_sdk
+        from sentry_sdk.integrations.logging import LoggingIntegration
+    except ImportError:
+        logging.warning("sentry_sdk is unavailable; continuing without Sentry")
+        return
 
-        response = requests.post(url, json=data, headers=headers, timeout=5)
-        response.raise_for_status()
+    sentry_logging = LoggingIntegration(
+        level=logging.INFO,
+        event_level=logging.ERROR,
+    )
+    sentry_sdk.init(
+        # Gate controller agent Sentry project DSN.
+        dsn="https://b3184994f9d267983dc3a5c99747b8b0@o4505847402135552.ingest.sentry.io/4505847409410048",
+        integrations=[
+            sentry_logging,
+        ],
+        traces_sample_rate=1.0,
+    )
 
-        command = response.json().get('status')
-        if command is None:
-            raise KeyError("The 'status' key is missing in the response")
-        logging.info(f"Command: {command}")
 
-        if command == 'closed':
-            logging.info(f"Turning off relay")
-            GPIO.output(relay1, GPIO.LOW)
-        elif command == 'open':
-            logging.info(f"Turning on relay")
-            GPIO.output(relay1, GPIO.HIGH)
-        else:
-            raise ValueError(f"Unknown command: {command}")
+class RelayController:
+    def __init__(self, pin, dry_run=False, gpio_module=None):
+        self.pin = pin
+        self.dry_run = dry_run
+        self._gpio = gpio_module
+
+    def setup(self):
+        if self.dry_run:
+            logging.warning(
+                "DRY RUN enabled: GPIO relay will not be initialized or modified"
+            )
+            return
+
+        if self._gpio is None:
+            import RPi.GPIO as GPIO
+
+            self._gpio = GPIO
+
+        self._gpio.setmode(self._gpio.BCM)
+        self._gpio.setup(self.pin, self._gpio.OUT)
+        logging.info("Initializing relay to off")
+        self._gpio.output(self.pin, self._gpio.LOW)
+
+    def open(self):
+        self._write("open", "HIGH")
+
+    def close(self):
+        self._write("closed", "LOW")
+
+    def cleanup(self):
+        if self.dry_run:
+            logging.warning("DRY RUN: skipping relay shutdown and GPIO cleanup")
+            return
+        if self._gpio is None:
+            return
+
+        logging.info("Turning off relays")
+        self._gpio.output(self.pin, self._gpio.LOW)
+
+        logging.info("Cleaning up!")
+        self._gpio.cleanup()
+
+    def _write(self, command, gpio_level_name):
+        if self.dry_run:
+            logging.warning(
+                "DRY RUN: command %r would set relay pin %s to GPIO.%s",
+                command,
+                self.pin,
+                gpio_level_name,
+            )
+            return
+
+        if self._gpio is None:
+            raise RuntimeError("RelayController.setup() must be called before use")
+
+        self._gpio.output(self.pin, getattr(self._gpio, gpio_level_name))
+
+
+def take_command(hostname):
+    data = {'host': hostname}
+    headers = {}
+    token = os.environ.get(AGENT_TOKEN_ENV)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    response = requests.post(GATE_STATUS_URL, json=data, headers=headers, timeout=5)
+    response.raise_for_status()
+
+    command = response.json().get('status')
+    if command is None:
+        raise KeyError("The 'status' key is missing in the response")
+    if command not in {"closed", "open"}:
+        raise ValueError(f"Unknown command: {command}")
+    return command
+
+
+def apply_command(command, relay):
+    logging.info(f"Command: {command}")
+
+    if command == 'closed':
+        logging.info("Turning off relay")
+        relay.close()
+    elif command == 'open':
+        logging.info("Turning on relay")
+        relay.open()
+    else:
+        raise ValueError(f"Unknown command: {command}")
+
+
+def loop_once(relay, hostname):
+    try:
+        apply_command(take_command(hostname), relay)
     except Exception as e:
         logging.error(f"Unexpected {e=}, {type(e)=}")
         logging.info("Sleeping for 2 seconds and trying again")
         time.sleep(2)
 
-@monitor(monitor_slug='gate-controller-agent')
+
 def ping_healthcheck():
-    sleep(0.5) # space out the begin and end API calls
+    time.sleep(0.5)  # space out the begin and end API calls
 
-# Continuously poll for the latest command
-try:
-    last_healthcheck_time = 0
-    while True:
-        loop_once()
-        now = time.time()
-        # Ping healthcheck every minute
-        if now - last_healthcheck_time > 60:
-            logging.info("Pinging healthcheck")
-            start = perf_counter()
-            ping_healthcheck()
-            stop = perf_counter()
-            logging.info(f"Healthcheck loop completed in {stop-start:.2f} seconds")
-            last_healthcheck_time = now
-        time.sleep(1)
-finally:
-    logging.info("Turning off relays")
-    GPIO.output(relay1, GPIO.LOW)
 
-    logging.info("Cleaning up!")
-    GPIO.cleanup()
+def build_healthcheck(dry_run):
+    if dry_run:
+        logging.warning("DRY RUN: Sentry cron monitor will not be pinged")
+        return ping_healthcheck
+
+    try:
+        from sentry_sdk.crons import monitor
+    except ImportError:
+        logging.warning("sentry_sdk is unavailable; healthcheck will not be monitored")
+        return ping_healthcheck
+
+    return monitor(monitor_slug=MONITOR_SLUG)(ping_healthcheck)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    dry_run = env_flag(DRY_RUN_ENV)
+    if not dry_run:
+        init_sentry()
+    monitored_healthcheck = build_healthcheck(dry_run)
+    relay = RelayController(RELAY_PIN, dry_run=dry_run)
+
+    hostname = socket.gethostname()
+
+    try:
+        relay.setup()
+        last_healthcheck_time = 0
+        while True:
+            loop_once(relay, hostname)
+            now = time.time()
+            # Ping healthcheck every minute
+            if now - last_healthcheck_time > 60:
+                logging.info("Pinging healthcheck")
+                start = time.perf_counter()
+                monitored_healthcheck()
+                stop = time.perf_counter()
+                logging.info(f"Healthcheck loop completed in {stop-start:.2f} seconds")
+                last_healthcheck_time = now
+            time.sleep(1)
+    finally:
+        relay.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/test_main.py
+++ b/agent/test_main.py
@@ -1,0 +1,162 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("main.py")
+spec = importlib.util.spec_from_file_location("agent_main", MODULE_PATH)
+agent_main = importlib.util.module_from_spec(spec)
+sys.modules["agent_main"] = agent_main
+spec.loader.exec_module(agent_main)
+
+
+def fake_gpio():
+    gpio = mock.Mock()
+    gpio.BCM = "BCM"
+    gpio.OUT = "OUT"
+    gpio.LOW = "LOW"
+    gpio.HIGH = "HIGH"
+    return gpio
+
+
+def fake_response(payload):
+    response = mock.Mock()
+    response.json.return_value = payload
+    return response
+
+
+class EnvFlagTests(unittest.TestCase):
+    def test_env_flag_accepts_true_values(self):
+        for value in ["1", "true", "TRUE", "yes", "on"]:
+            with self.subTest(value=value):
+                with mock.patch.dict(agent_main.os.environ, {"FLAG": value}, clear=True):
+                    self.assertTrue(agent_main.env_flag("FLAG"))
+
+    def test_env_flag_accepts_false_values(self):
+        for value in ["", "0", "false", "FALSE", "no", "off"]:
+            with self.subTest(value=value):
+                with mock.patch.dict(agent_main.os.environ, {"FLAG": value}, clear=True):
+                    self.assertFalse(agent_main.env_flag("FLAG"))
+
+    def test_env_flag_rejects_ambiguous_values(self):
+        with mock.patch.dict(agent_main.os.environ, {"FLAG": "enabled"}, clear=True):
+            with self.assertRaisesRegex(ValueError, "FLAG must be one of"):
+                agent_main.env_flag("FLAG")
+
+
+class RelayControllerTests(unittest.TestCase):
+    def test_dry_run_never_imports_or_writes_gpio(self):
+        relay = agent_main.RelayController(pin=4, dry_run=True)
+
+        with self.assertLogs(level="WARNING") as logs:
+            relay.setup()
+            relay.open()
+            relay.close()
+            relay.cleanup()
+
+        self.assertIsNone(relay._gpio)
+        self.assertTrue(any("DRY RUN enabled" in line for line in logs.output))
+        self.assertTrue(
+            any("would set relay pin 4 to GPIO.HIGH" in line for line in logs.output)
+        )
+        self.assertTrue(
+            any("would set relay pin 4 to GPIO.LOW" in line for line in logs.output)
+        )
+
+    def test_real_mode_initializes_writes_and_cleans_up_gpio(self):
+        gpio = fake_gpio()
+        relay = agent_main.RelayController(pin=4, dry_run=False, gpio_module=gpio)
+
+        relay.setup()
+        relay.open()
+        relay.close()
+        relay.cleanup()
+
+        self.assertEqual(
+            gpio.method_calls,
+            [
+                mock.call.setmode("BCM"),
+                mock.call.setup(4, "OUT"),
+                mock.call.output(4, "LOW"),
+                mock.call.output(4, "HIGH"),
+                mock.call.output(4, "LOW"),
+                mock.call.output(4, "LOW"),
+                mock.call.cleanup(),
+            ],
+        )
+
+
+class TakeCommandTests(unittest.TestCase):
+    def test_take_command_sends_agent_token_and_returns_status(self):
+        response = fake_response({"status": "open"})
+
+        with mock.patch.dict(
+            agent_main.os.environ,
+            {agent_main.AGENT_TOKEN_ENV: "secret"},
+            clear=True,
+        ):
+            with mock.patch.object(
+                agent_main.requests,
+                "post",
+                return_value=response,
+            ) as post:
+                self.assertEqual(agent_main.take_command("pi-host"), "open")
+
+        post.assert_called_once_with(
+            agent_main.GATE_STATUS_URL,
+            json={"host": "pi-host"},
+            headers={"Authorization": "Bearer secret"},
+            timeout=5,
+        )
+        response.raise_for_status.assert_called_once_with()
+
+    def test_take_command_rejects_missing_status(self):
+        with mock.patch.object(
+            agent_main.requests,
+            "post",
+            return_value=fake_response({"error": "Unauthorized"}),
+        ):
+            with self.assertRaisesRegex(KeyError, "status"):
+                agent_main.take_command("pi-host")
+
+    def test_apply_command_rejects_unknown_status_without_touching_relay(self):
+        relay = mock.Mock()
+
+        with self.assertRaisesRegex(ValueError, "Unknown command"):
+            agent_main.apply_command("jammed", relay)
+
+        self.assertEqual(relay.method_calls, [])
+
+
+class HealthcheckTests(unittest.TestCase):
+    def test_dry_run_healthcheck_does_not_use_sentry_monitor(self):
+        with mock.patch.object(agent_main.logging, "warning") as warning:
+            self.assertIs(
+                agent_main.build_healthcheck(True),
+                agent_main.ping_healthcheck,
+            )
+
+        warning.assert_called_once_with(
+            "DRY RUN: Sentry cron monitor will not be pinged"
+        )
+
+    def test_live_healthcheck_uses_agent_sentry_monitor(self):
+        wrapped = mock.Mock()
+        sentry_sdk = types.ModuleType("sentry_sdk")
+        crons = types.ModuleType("sentry_sdk.crons")
+        crons.monitor = mock.Mock(return_value=lambda func: wrapped)
+
+        with mock.patch.dict(
+            sys.modules,
+            {"sentry_sdk": sentry_sdk, "sentry_sdk.crons": crons},
+        ):
+            self.assertIs(agent_main.build_healthcheck(False), wrapped)
+
+        crons.monitor.assert_called_once_with(monitor_slug=agent_main.MONITOR_SLUG)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `GATE_CONTROLLER_AGENT_DRY_RUN=1` for the gate agent so it can poll and log intended relay actions without importing, initializing, writing, or cleaning up GPIO.
- Keep dry-run polling identical to normal cloud polling, so `/api/gate/take_status` still updates `lastContactTimestamp` for end-to-end server/agent validation.
- Skip Sentry initialization and cron monitoring in dry-run so it cannot mask the real physical agent monitor.
- Add Python unit coverage for dry-run GPIO safety, live GPIO behavior, request handling, and healthcheck behavior.

## Validation
- `python3 -m unittest discover agent`
- `python3 -m py_compile agent/main.py agent/test_main.py`
- `GATE_CONTROLLER_AGENT_TOKEN=dummy GATE_CONTROLLER_AGENT_DRY_RUN=1 docker compose -f agent/docker-compose.yml config`
- `git diff --check`
- `npm run lint`
- `npm run typecheck`
- `npm run e2e`
