### PR TITLE
[codex] require gate agent token for compose

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -6,9 +6,9 @@ pip install -r requirements.txt
 sudo -E python3 main.py
 ```
 
-Set `GATE_CONTROLLER_AGENT_TOKEN` if the cloud app has `AGENT_TOKEN` configured.
+Set `GATE_CONTROLLER_AGENT_TOKEN` to match the cloud app's `AGENT_TOKEN`.
 For Docker Compose, put it in `agent/.env` or export it in the shell before
-starting the service.
+starting the service. Compose fails fast if the variable is missing.
 
 Always-on service:
 ```bash

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: gate_controller_agent
     build: .
     environment:
-      GATE_CONTROLLER_AGENT_TOKEN: ${GATE_CONTROLLER_AGENT_TOKEN:-}
+      GATE_CONTROLLER_AGENT_TOKEN: "${GATE_CONTROLLER_AGENT_TOKEN:?set GATE_CONTROLLER_AGENT_TOKEN}"
     volumes:
       - ./:/workspace
       - /dev/mem:/dev/mem


### PR DESCRIPTION
## Summary

- Make `agent/docker-compose.yml` fail fast when `GATE_CONTROLLER_AGENT_TOKEN` is missing or empty.
- Update the agent README to state that the token must match the cloud app's `AGENT_TOKEN` and that Compose validates it.

## Why

The gate agent can silently start without bearer auth when Compose resolves `${GATE_CONTROLLER_AGENT_TOKEN:-}` to an empty string. In production that caused repeated `401 Unauthorized` responses from `/api/gate/take_status` because the cloud app requires `Authorization: Bearer TOKEN` when `AGENT_TOKEN` is configured.

## Validation

- `env -u GATE_CONTROLLER_AGENT_TOKEN docker compose -f agent/docker-compose.yml config` now fails with the required-variable error.
- `GATE_CONTROLLER_AGENT_TOKEN=dummy docker compose -f agent/docker-compose.yml config` renders successfully.
- `python3 -m py_compile agent/main.py`
- `git diff --check`