### PR TITLE
[codex] add AI schedule drafting

### DIFF
--- a/.github/workflows/cloud-v3-checks.yml
+++ b/.github/workflows/cloud-v3-checks.yml
@@ -28,3 +28,5 @@ jobs:
       - run: npm run typecheck
       - run: npx playwright install --with-deps chromium
       - run: npm run e2e
+        env:
+          E2E_OPENAI_API_KEY: ${{ secrets.E2E_OPENAI_API_KEY }}

--- a/agent/README.md
+++ b/agent/README.md
@@ -6,9 +6,9 @@ pip install -r requirements.txt
 sudo -E python3 main.py
 ```
 
-Set `GATE_CONTROLLER_AGENT_TOKEN` if the cloud app has `AGENT_TOKEN` configured.
+Set `GATE_CONTROLLER_AGENT_TOKEN` to match the cloud app's `AGENT_TOKEN`.
 For Docker Compose, put it in `agent/.env` or export it in the shell before
-starting the service.
+starting the service. Compose fails fast if the variable is missing.
 
 Always-on service:
 ```bash

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: gate_controller_agent
     build: .
     environment:
-      GATE_CONTROLLER_AGENT_TOKEN: ${GATE_CONTROLLER_AGENT_TOKEN:-}
+      GATE_CONTROLLER_AGENT_TOKEN: "${GATE_CONTROLLER_AGENT_TOKEN:?set GATE_CONTROLLER_AGENT_TOKEN}"
     volumes:
       - ./:/workspace
       - /dev/mem:/dev/mem

--- a/cloud-v3/package-lock.json
+++ b/cloud-v3/package-lock.json
@@ -11,6 +11,7 @@
         "bcryptjs": "^3.0.2",
         "better-sqlite3": "^11.9.1",
         "bullmq": "^5.45.2",
+        "cron-parser": "^4.9.0",
         "cronstrue": "^2.57.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",

--- a/cloud-v3/package.json
+++ b/cloud-v3/package.json
@@ -19,6 +19,7 @@
     "bcryptjs": "^3.0.2",
     "better-sqlite3": "^11.9.1",
     "bullmq": "^5.45.2",
+    "cron-parser": "^4.9.0",
     "cronstrue": "^2.57.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/cloud-v3/scripts/e2e-server.mjs
+++ b/cloud-v3/scripts/e2e-server.mjs
@@ -20,6 +20,8 @@ const childEnv = {
   ...process.env,
   NODE_ENV: "production",
   NEXT_PUBLIC_CONTROLLER_TIMEZONE: "UTC",
+  OPENAI_API_KEY: process.env.E2E_OPENAI_API_KEY ?? "",
+  OPENAI_SCHEDULE_MODEL: process.env.E2E_OPENAI_SCHEDULE_MODEL ?? "gpt-5.5",
   PORT: port,
   REDIS_HOST: "127.0.0.1",
   REDIS_PORT: redisPort,

--- a/cloud-v3/src/app/api/schedules/draft/route.ts
+++ b/cloud-v3/src/app/api/schedules/draft/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from "next/server";
+import { getSchedules } from "@/lib/db";
+import { draftSchedules } from "@/lib/schedule-drafts";
+import {
+  apiError,
+  readJsonBody,
+  requireApiSession,
+  requireObject,
+  requireString,
+} from "@/lib/api";
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireApiSession();
+    const body = requireObject(await readJsonBody(request));
+    const prompt = requireString(body, "prompt");
+
+    return Response.json(await draftSchedules(prompt, getSchedules()));
+  } catch (error) {
+    return apiError(error, "Error drafting schedules:");
+  }
+}

--- a/cloud-v3/src/app/api/schedules/draft/stream/route.ts
+++ b/cloud-v3/src/app/api/schedules/draft/stream/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest } from "next/server";
+import { getSchedules } from "@/lib/db";
+import {
+  draftSchedules,
+  requireScheduleDraftingConfigured,
+} from "@/lib/schedule-drafts";
+import {
+  apiError,
+  ApiError,
+  readJsonBody,
+  requireApiSession,
+  requireObject,
+  requireString,
+} from "@/lib/api";
+import { ScheduleDraftStreamEvent } from "@/types/schedule";
+
+const encoder = new TextEncoder();
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireApiSession();
+    const body = requireObject(await readJsonBody(request));
+    const prompt = requireString(body, "prompt");
+    requireScheduleDraftingConfigured();
+    const schedules = getSchedules();
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const send = (event: ScheduleDraftStreamEvent) => {
+          controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+        };
+
+        try {
+          send({
+            type: "progress",
+            title: "Reading the request",
+            detail: "Checking the prompt against existing schedules.",
+          });
+          const result = await draftSchedules(prompt, schedules, (progress) =>
+            send({ type: "progress", ...progress })
+          );
+          send({ type: "result", result });
+        } catch (error) {
+          if (!(error instanceof ApiError)) {
+            console.error("Error drafting schedules:", error);
+          }
+          send({
+            type: "error",
+            error: error instanceof Error ? error.message : "Failed to draft schedules",
+          });
+        } finally {
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Cache-Control": "no-cache, no-transform",
+        "Content-Type": "application/x-ndjson; charset=utf-8",
+      },
+    });
+  } catch (error) {
+    return apiError(error, "Error drafting schedules:");
+  }
+}

--- a/cloud-v3/src/components/schedule-manager.tsx
+++ b/cloud-v3/src/components/schedule-manager.tsx
@@ -13,6 +13,7 @@ import cronstrue from 'cronstrue';
 import {
   Schedule,
   ScheduleDraft,
+  ScheduleDraftProgress,
   ScheduleDraftResponse,
   ScheduleInput,
 } from '@/types/schedule';
@@ -39,6 +40,7 @@ export function ScheduleManager() {
   const [cronError, setCronError] = useState<string | null>(null);
   const [prompt, setPrompt] = useState('');
   const [draftResult, setDraftResult] = useState<ScheduleDraftResponse | null>(null);
+  const [draftProgress, setDraftProgress] = useState<ScheduleDraftProgress | null>(null);
   const [isDrafting, setIsDrafting] = useState(false);
   const [applyingDraft, setApplyingDraft] = useState<string | null>(null);
 
@@ -64,12 +66,18 @@ export function ScheduleManager() {
     try {
       setError(null);
       setIsDrafting(true);
-      setDraftResult(await draftSchedules(trimmedPrompt));
+      setDraftResult(null);
+      setDraftProgress({
+        title: 'Starting draft',
+        detail: 'Preparing the schedule request.',
+      });
+      setDraftResult(await draftSchedules(trimmedPrompt, setDraftProgress));
     } catch (error) {
       console.error('Failed to draft schedules:', error);
       setError(error instanceof Error ? error.message : 'Failed to draft schedules');
     } finally {
       setIsDrafting(false);
+      setDraftProgress(null);
     }
   };
 
@@ -261,6 +269,7 @@ export function ScheduleManager() {
             </button>
           ))}
         </div>
+        {draftProgress && <DraftingNotice progress={draftProgress} />}
       </form>
 
       {draftResult && (
@@ -298,6 +307,28 @@ export function ScheduleManager() {
           No schedules found.
         </div>
       )}
+    </div>
+  );
+}
+
+function DraftingNotice({ progress }: { progress: ScheduleDraftProgress }) {
+  return (
+    <div
+      className="rounded-lg border border-blue-200 bg-white p-3 text-sm dark:border-blue-900 dark:bg-gray-900"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-1 h-2.5 w-2.5 shrink-0 animate-pulse rounded-full bg-blue-600" />
+        <div className="min-w-0">
+          <div className="font-medium text-gray-900 dark:text-gray-100">
+            {progress.title}
+          </div>
+          <p className="mt-1 text-gray-600 dark:text-gray-400">{progress.detail}</p>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            No gate command is being sent.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/cloud-v3/src/components/schedule-manager.tsx
+++ b/cloud-v3/src/components/schedule-manager.tsx
@@ -1,16 +1,34 @@
 'use client';
 
 import { useState } from 'react';
-import { useSchedules, createSchedule, updateSchedule, deleteSchedule } from '@/hooks/useSchedules';
+import {
+  createSchedule,
+  deleteSchedule,
+  draftSchedules,
+  updateSchedule,
+  useSchedules,
+} from '@/hooks/useSchedules';
+import { publicConfig } from '@/config';
 import cronstrue from 'cronstrue';
-import { Schedule, ScheduleInput } from '@/types/schedule';
+import {
+  Schedule,
+  ScheduleDraft,
+  ScheduleDraftResponse,
+  ScheduleInput,
+} from '@/types/schedule';
 
 const DEFAULT_FORM_DATA: ScheduleInput = Object.freeze({
   name: '',
   cron_expression: '',
   action: 'close',
-  enabled: true
+  enabled: true,
 });
+
+const PROMPT_EXAMPLES = [
+  'Open weekdays at 7:30 AM',
+  'Close every night at 6 PM',
+  'Open Saturday and Sunday at 9 AM',
+];
 
 export function ScheduleManager() {
   const { schedules, isLoading, isError, mutate } = useSchedules();
@@ -19,15 +37,78 @@ export function ScheduleManager() {
   const [error, setError] = useState<string | null>(null);
   const [formData, setFormData] = useState<ScheduleInput>(DEFAULT_FORM_DATA);
   const [cronError, setCronError] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState('');
+  const [draftResult, setDraftResult] = useState<ScheduleDraftResponse | null>(null);
+  const [isDrafting, setIsDrafting] = useState(false);
+  const [applyingDraft, setApplyingDraft] = useState<string | null>(null);
 
   const validateCronExpression = (expression: string): boolean => {
     try {
+      if (expression.trim().split(/\s+/).length !== 5) {
+        throw new Error('Expected five cron fields');
+      }
       cronstrue.toString(expression);
       setCronError(null);
       return true;
     } catch {
       setCronError('Invalid cron expression');
       return false;
+    }
+  };
+
+  const handleDraftSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt) return;
+
+    try {
+      setError(null);
+      setIsDrafting(true);
+      setDraftResult(await draftSchedules(trimmedPrompt));
+    } catch (error) {
+      console.error('Failed to draft schedules:', error);
+      setError(error instanceof Error ? error.message : 'Failed to draft schedules');
+    } finally {
+      setIsDrafting(false);
+    }
+  };
+
+  const handleApplyDraft = async (draft: ScheduleDraft) => {
+    try {
+      setError(null);
+      setApplyingDraft(draft.name);
+      await createSchedule(toScheduleInput(draft));
+      setDraftResult((current) => {
+        if (!current) return current;
+        const drafts = current.drafts.filter((item) => item.name !== draft.name);
+        return drafts.length ? { ...current, drafts } : null;
+      });
+      await mutate();
+    } catch (error) {
+      console.error('Failed to apply schedule draft:', error);
+      setError(error instanceof Error ? error.message : 'Failed to apply schedule draft');
+    } finally {
+      setApplyingDraft(null);
+    }
+  };
+
+  const handleApplyAllDrafts = async () => {
+    if (!draftResult?.drafts.length) return;
+
+    try {
+      setError(null);
+      setApplyingDraft('all');
+      for (const draft of draftResult.drafts) {
+        await createSchedule(toScheduleInput(draft));
+      }
+      setDraftResult(null);
+      setPrompt('');
+      await mutate();
+    } catch (error) {
+      console.error('Failed to apply schedule drafts:', error);
+      setError(error instanceof Error ? error.message : 'Failed to apply schedule drafts');
+    } finally {
+      setApplyingDraft(null);
     }
   };
 
@@ -62,8 +143,14 @@ export function ScheduleManager() {
       name: schedule.name,
       cron_expression: schedule.cron_expression,
       action: schedule.action,
-      enabled: schedule.enabled
+      enabled: schedule.enabled,
     });
+  };
+
+  const handleEditDraft = (draft: ScheduleDraft) => {
+    setIsFormOpen(true);
+    setEditingName(null);
+    setFormData(toScheduleInput(draft));
   };
 
   const handleDelete = async (name: string) => {
@@ -97,6 +184,9 @@ export function ScheduleManager() {
 
   const getCronDescription = (cron_expression: string) => {
     try {
+      if (cron_expression.trim().split(/\s+/).length !== 5) {
+        throw new Error('Expected five cron fields');
+      }
       return cronstrue.toString(cron_expression);
     } catch {
       return `Invalid cron expression: ${cron_expression}`;
@@ -116,232 +206,468 @@ export function ScheduleManager() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       {error && (
-        <div className="bg-red-50 dark:bg-red-900/50 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/50 dark:text-red-300">
           {error}
         </div>
       )}
-      <div className="space-y-6">
-        <div className="flex justify-between items-center">
-          <h2 className="text-xl font-semibold">Schedule Manager</h2>
-          {!isFormOpen && (
-            <button
-              onClick={() => setIsFormOpen(true)}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              Add Schedule
-            </button>
-          )}
-        </div>
 
-        {isFormOpen && (
-          <form onSubmit={handleSubmit} className="space-y-4 bg-gray-50 dark:bg-gray-800/50 p-4 rounded-lg">
-            <div>
-              <label htmlFor="schedule-name" className="block text-sm font-medium mb-1">Name</label>
-              <input
-                id="schedule-name"
-                type="text"
-                value={formData.name}
-                disabled={!!editingName}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
-                  !!editingName
-                    ? 'bg-gray-100 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'
-                    : 'border-gray-300 dark:border-gray-700'
-                }`}
-                required
-              />
-              {
-                editingName && (
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    Schedule name cannot be changed after creation
-                  </p>
-                )
-              }
-            </div>
-            <div>
-              <label htmlFor="schedule-cron-expression" className="block text-sm font-medium mb-1">Cron Expression</label>
-              <input
-                id="schedule-cron-expression"
-                type="text"
-                value={formData.cron_expression}
-                onChange={handleCronChange}
-                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
-                  cronError ? 'border-red-500 dark:border-red-500' : 'border-gray-300 dark:border-gray-700'
-                }`}
-                placeholder="* * * * *"
-                required
-              />
-              {formData.cron_expression && (
-                <p className={`mt-1 text-sm ${
-                  cronError ? 'text-red-600 dark:text-red-400' : 'text-gray-600 dark:text-gray-400'
-                }`}>
-                  {cronError || getCronDescription(formData.cron_expression)}
-                </p>
-              )}
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Format: minute hour day month weekday (e.g., &quot;0 8 * * 1-5&quot; for weekdays at 8 AM)
-              </p>
-            </div>
-            <div>
-              <label htmlFor="schedule-action" className="block text-sm font-medium mb-1">Action</label>
-              <select
-                id="schedule-action"
-                value={formData.action}
-                onChange={(e) => setFormData({ ...formData, action: e.target.value as 'open' | 'close' })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800"
-              >
-                <option value="close">Close</option>
-                <option value="open">Open</option>
-              </select>
-            </div>
-            <div className="flex items-center">
-              <input
-                type="checkbox"
-                id="enabled"
-                checked={formData.enabled}
-                onChange={(e) => setFormData({ ...formData, enabled: e.target.checked })}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              />
-              <label htmlFor="enabled" className="ml-2 block text-sm">
-                Enabled
-              </label>
-            </div>
-            <div className="flex gap-2">
-              <button
-                type="submit"
-                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
-              >
-                {editingName ? 'Update' : 'Create'} Schedule
-              </button>
-              <button
-                type="button"
-                onClick={handleCancel}
-                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
-        )}
-
-        {schedules && schedules.length > 0 ? (
-          <>
-            <div className="space-y-3 sm:hidden">
-              {schedules.map((schedule) => (
-                <div
-                  key={schedule.name}
-                  className="rounded-lg bg-gray-50 p-4 text-sm dark:bg-gray-800/50"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="font-medium">{schedule.name}</div>
-                      <div className="mt-1 font-mono text-xs text-gray-600 dark:text-gray-400">
-                        {schedule.cron_expression}
-                      </div>
-                    </div>
-                    <ScheduleStatus enabled={schedule.enabled} />
-                  </div>
-                  <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
-                    {getCronDescription(schedule.cron_expression)}
-                  </div>
-                  <div className="mt-3 flex items-center justify-between gap-3">
-                    <span className="text-gray-600 dark:text-gray-400">
-                      Action: <span className="font-medium text-gray-900 dark:text-gray-100">{schedule.action}</span>
-                    </span>
-                    <div className="shrink-0 text-sm">
-                      <button
-                        onClick={() => handleEdit(schedule)}
-                        className="mr-3 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        onClick={() => handleDelete(schedule.name)}
-                        className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            <div className="hidden overflow-x-auto rounded-lg bg-gray-50 dark:bg-gray-800/50 sm:block">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-100 dark:bg-gray-800">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Schedule
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Cron Expression
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Action
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Status
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white dark:bg-transparent divide-y divide-gray-200 dark:divide-gray-700">
-                  {schedules.map((schedule) => (
-                    <tr key={schedule.name}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        {schedule.name}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        <div>{schedule.cron_expression}</div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400">
-                          {getCronDescription(schedule.cron_expression)}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        {schedule.action}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        <ScheduleStatus enabled={schedule.enabled} />
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
-                        <button
-                          onClick={() => handleEdit(schedule)}
-                          className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 mr-3"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          onClick={() => handleDelete(schedule.name)}
-                          className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
-                        >
-                          Delete
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </>
-        ) : (
-          <div className="text-center py-12 text-gray-500 dark:text-gray-400">
-            No schedules found. Click &quot;Add Schedule&quot; to create one.
-          </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-xl font-semibold">Schedules</h2>
+        {!isFormOpen && (
+          <button
+            onClick={() => setIsFormOpen(true)}
+            className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-800 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+          >
+            Add Schedule
+          </button>
         )}
       </div>
+
+      <form
+        onSubmit={handleDraftSubmit}
+        className="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50"
+      >
+        <label htmlFor="schedule-prompt" className="block text-sm font-medium">
+          Describe schedule
+        </label>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <textarea
+            id="schedule-prompt"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            rows={2}
+            className="min-h-20 flex-1 resize-y rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800"
+            placeholder="Open weekdays at 7:30 AM and close at 6 PM"
+          />
+          <button
+            type="submit"
+            disabled={isDrafting || !prompt.trim()}
+            className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400 sm:self-start"
+          >
+            {isDrafting ? 'Drafting...' : 'Draft'}
+          </button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {PROMPT_EXAMPLES.map((example) => (
+            <button
+              key={example}
+              type="button"
+              onClick={() => setPrompt(example)}
+              className="rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-700 transition-colors hover:bg-white dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              {example}
+            </button>
+          ))}
+        </div>
+      </form>
+
+      {draftResult && (
+        <DraftReview
+          result={draftResult}
+          applyingDraft={applyingDraft}
+          onApply={handleApplyDraft}
+          onApplyAll={handleApplyAllDrafts}
+          onEdit={handleEditDraft}
+        />
+      )}
+
+      {isFormOpen && (
+        <ScheduleForm
+          cronError={cronError}
+          editingName={editingName}
+          formData={formData}
+          getCronDescription={getCronDescription}
+          onCancel={handleCancel}
+          onCronChange={handleCronChange}
+          onSubmit={handleSubmit}
+          setFormData={setFormData}
+        />
+      )}
+
+      {schedules.length > 0 ? (
+        <ScheduleList
+          schedules={schedules}
+          getCronDescription={getCronDescription}
+          onDelete={handleDelete}
+          onEdit={handleEdit}
+        />
+      ) : (
+        <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+          No schedules found.
+        </div>
+      )}
     </div>
+  );
+}
+
+function DraftReview({
+  applyingDraft,
+  onApply,
+  onApplyAll,
+  onEdit,
+  result,
+}: {
+  applyingDraft: string | null;
+  onApply: (draft: ScheduleDraft) => void;
+  onApplyAll: () => void;
+  onEdit: (draft: ScheduleDraft) => void;
+  result: ScheduleDraftResponse;
+}) {
+  const hasDrafts = result.drafts.length > 0;
+
+  return (
+    <div className="space-y-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950/40">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h3 className="font-medium">Review Drafts</h3>
+          {result.interpretation && (
+            <p className="mt-1 text-sm text-gray-700 dark:text-gray-300">
+              {result.interpretation}
+            </p>
+          )}
+        </div>
+        {hasDrafts && (
+          <button
+            type="button"
+            onClick={onApplyAll}
+            disabled={applyingDraft !== null}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+          >
+            {applyingDraft === 'all' ? 'Applying...' : 'Apply All'}
+          </button>
+        )}
+      </div>
+
+      <NoticeList tone="amber" items={result.questions} />
+      <NoticeList tone="gray" items={result.warnings} />
+
+      {hasDrafts ? (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {result.drafts.map((draft) => (
+            <div
+              key={draft.name}
+              className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="font-medium">{draft.name}</div>
+                  <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {draft.summary || draft.description}
+                  </div>
+                </div>
+                <ActionBadge action={draft.action} />
+              </div>
+              <div className="mt-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+                {draft.cron_expression}
+              </div>
+              <div className="mt-3 space-y-1 text-xs text-gray-600 dark:text-gray-400">
+                {draft.nextExecutions.slice(0, 3).map((execution) => (
+                  <div key={execution}>{formatExecution(execution)}</div>
+                ))}
+              </div>
+              <div className="mt-4 flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => onApply(draft)}
+                  disabled={applyingDraft !== null}
+                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+                >
+                  {applyingDraft === draft.name ? 'Applying...' : 'Apply'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onEdit(draft)}
+                  className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-800 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                >
+                  Edit
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg bg-white p-4 text-sm text-gray-600 dark:bg-gray-900 dark:text-gray-300">
+          No draft schedules.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NoticeList({ items, tone }: { items: string[]; tone: 'amber' | 'gray' }) {
+  if (items.length === 0) return null;
+
+  const classes =
+    tone === 'amber'
+      ? 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200'
+      : 'border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300';
+
+  return (
+    <div className={`space-y-1 rounded-lg border p-3 text-sm ${classes}`}>
+      {items.map((item) => (
+        <div key={item}>{item}</div>
+      ))}
+    </div>
+  );
+}
+
+function ScheduleForm({
+  cronError,
+  editingName,
+  formData,
+  getCronDescription,
+  onCancel,
+  onCronChange,
+  onSubmit,
+  setFormData,
+}: {
+  cronError: string | null;
+  editingName: string | null;
+  formData: ScheduleInput;
+  getCronDescription: (cronExpression: string) => string;
+  onCancel: () => void;
+  onCronChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  setFormData: (data: ScheduleInput) => void;
+}) {
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="space-y-4 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50"
+    >
+      <div>
+        <label htmlFor="schedule-name" className="mb-1 block text-sm font-medium">
+          Name
+        </label>
+        <input
+          id="schedule-name"
+          type="text"
+          value={formData.name}
+          disabled={!!editingName}
+          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+          className={`w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
+            !!editingName
+              ? 'border-gray-300 bg-gray-100 text-gray-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400'
+              : 'border-gray-300 dark:border-gray-700'
+          }`}
+          required
+        />
+      </div>
+      <div>
+        <label htmlFor="schedule-cron-expression" className="mb-1 block text-sm font-medium">
+          Cron Expression
+        </label>
+        <input
+          id="schedule-cron-expression"
+          type="text"
+          value={formData.cron_expression}
+          onChange={onCronChange}
+          className={`w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
+            cronError ? 'border-red-500 dark:border-red-500' : 'border-gray-300 dark:border-gray-700'
+          }`}
+          placeholder="0 8 * * 1-5"
+          required
+        />
+        {formData.cron_expression && (
+          <p
+            className={`mt-1 text-sm ${
+              cronError ? 'text-red-600 dark:text-red-400' : 'text-gray-600 dark:text-gray-400'
+            }`}
+          >
+            {cronError || getCronDescription(formData.cron_expression)}
+          </p>
+        )}
+      </div>
+      <div>
+        <label htmlFor="schedule-action" className="mb-1 block text-sm font-medium">
+          Action
+        </label>
+        <select
+          id="schedule-action"
+          value={formData.action}
+          onChange={(e) =>
+            setFormData({ ...formData, action: e.target.value as 'open' | 'close' })
+          }
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800"
+        >
+          <option value="close">Close</option>
+          <option value="open">Open</option>
+        </select>
+      </div>
+      <div className="flex items-center">
+        <input
+          type="checkbox"
+          id="enabled"
+          checked={formData.enabled}
+          onChange={(e) => setFormData({ ...formData, enabled: e.target.checked })}
+          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+        />
+        <label htmlFor="enabled" className="ml-2 block text-sm">
+          Enabled
+        </label>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+        >
+          {editingName ? 'Update' : 'Create'} Schedule
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ScheduleList({
+  getCronDescription,
+  onDelete,
+  onEdit,
+  schedules,
+}: {
+  getCronDescription: (cronExpression: string) => string;
+  onDelete: (name: string) => void;
+  onEdit: (schedule: Schedule) => void;
+  schedules: Schedule[];
+}) {
+  return (
+    <>
+      <div className="space-y-3 sm:hidden">
+        {schedules.map((schedule) => (
+          <div
+            key={schedule.name}
+            className="rounded-lg bg-gray-50 p-4 text-sm dark:bg-gray-800/50"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="font-medium">{schedule.name}</div>
+                <div className="mt-1 font-mono text-xs text-gray-600 dark:text-gray-400">
+                  {schedule.cron_expression}
+                </div>
+              </div>
+              <ScheduleStatus enabled={schedule.enabled} />
+            </div>
+            <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+              {getCronDescription(schedule.cron_expression)}
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <span className="text-gray-600 dark:text-gray-400">
+                Action:{' '}
+                <span className="font-medium text-gray-900 dark:text-gray-100">
+                  {schedule.action}
+                </span>
+              </span>
+              <div className="shrink-0 text-sm">
+                <button
+                  onClick={() => onEdit(schedule)}
+                  className="mr-3 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => onDelete(schedule.name)}
+                  className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="hidden overflow-x-auto rounded-lg bg-gray-50 dark:bg-gray-800/50 sm:block">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-100 dark:bg-gray-800">
+            <tr>
+              <TableHeader>Schedule</TableHeader>
+              <TableHeader>Cron Expression</TableHeader>
+              <TableHeader>Action</TableHeader>
+              <TableHeader>Status</TableHeader>
+              <TableHeader align="right">Actions</TableHeader>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-transparent">
+            {schedules.map((schedule) => (
+              <tr key={schedule.name}>
+                <td className="whitespace-nowrap px-6 py-4 text-sm">{schedule.name}</td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm">
+                  <div>{schedule.cron_expression}</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {getCronDescription(schedule.cron_expression)}
+                  </div>
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm">{schedule.action}</td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm">
+                  <ScheduleStatus enabled={schedule.enabled} />
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-right text-sm">
+                  <button
+                    onClick={() => onEdit(schedule)}
+                    className="mr-3 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => onDelete(schedule.name)}
+                    className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function TableHeader({
+  align = 'left',
+  children,
+}: {
+  align?: 'left' | 'right';
+  children: React.ReactNode;
+}) {
+  const alignClass = align === 'right' ? 'text-right' : 'text-left';
+
+  return (
+    <th
+      className={`px-6 py-3 ${alignClass} text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function ActionBadge({ action }: { action: 'open' | 'close' }) {
+  return (
+    <span
+      className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
+        action === 'open'
+          ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200'
+          : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200'
+      }`}
+    >
+      {action}
+    </span>
   );
 }
 
 function ScheduleStatus({ enabled }: { enabled: boolean }) {
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+      className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
         enabled
           ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200'
           : 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-200'
@@ -350,4 +676,24 @@ function ScheduleStatus({ enabled }: { enabled: boolean }) {
       {enabled ? 'Enabled' : 'Disabled'}
     </span>
   );
+}
+
+function toScheduleInput(draft: ScheduleDraft): ScheduleInput {
+  return {
+    name: draft.name,
+    cron_expression: draft.cron_expression,
+    action: draft.action,
+    enabled: draft.enabled,
+  };
+}
+
+function formatExecution(execution: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: publicConfig.controllerTimezone,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(execution));
 }

--- a/cloud-v3/src/config.ts
+++ b/cloud-v3/src/config.ts
@@ -29,6 +29,7 @@ export const publicConfig = {
 export const config = {
   ...publicConfig,
   dbPath: process.env.DB_PATH || "data/gate.db",
+  scheduleDraftModel: process.env.OPENAI_SCHEDULE_MODEL || "gpt-5.5",
   redis: {
     host: process.env.REDIS_HOST || "localhost",
     port: parsePort(process.env.REDIS_PORT, 6379),
@@ -42,4 +43,5 @@ export const secrets = {
     { username: "admin", password: "replace_me" }
   ),
   agentToken: process.env.AGENT_TOKEN || "",
+  openaiApiKey: process.env.OPENAI_API_KEY || "",
 } as const;

--- a/cloud-v3/src/hooks/useSchedules.ts
+++ b/cloud-v3/src/hooks/useSchedules.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { Schedule, ScheduleInput } from '@/types/schedule';
+import { Schedule, ScheduleDraftResponse, ScheduleInput } from '@/types/schedule';
 
 const fetcher = async (url: string) => {
   const res = await fetch(url);
@@ -32,6 +32,23 @@ export async function createSchedule(schedule: ScheduleInput) {
   if (!res.ok) {
     const errorData = await res.json();
     throw new Error(errorData.error || 'Failed to create schedule');
+  }
+
+  return res.json();
+}
+
+export async function draftSchedules(prompt: string): Promise<ScheduleDraftResponse> {
+  const res = await fetch('/api/schedules/draft', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ prompt }),
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json();
+    throw new Error(errorData.error || 'Failed to draft schedules');
   }
 
   return res.json();

--- a/cloud-v3/src/hooks/useSchedules.ts
+++ b/cloud-v3/src/hooks/useSchedules.ts
@@ -1,5 +1,11 @@
 import useSWR from 'swr';
-import { Schedule, ScheduleDraftResponse, ScheduleInput } from '@/types/schedule';
+import {
+  Schedule,
+  ScheduleDraftProgress,
+  ScheduleDraftResponse,
+  ScheduleDraftStreamEvent,
+  ScheduleInput,
+} from '@/types/schedule';
 
 const fetcher = async (url: string) => {
   const res = await fetch(url);
@@ -37,8 +43,11 @@ export async function createSchedule(schedule: ScheduleInput) {
   return res.json();
 }
 
-export async function draftSchedules(prompt: string): Promise<ScheduleDraftResponse> {
-  const res = await fetch('/api/schedules/draft', {
+export async function draftSchedules(
+  prompt: string,
+  onProgress?: (progress: ScheduleDraftProgress) => void
+): Promise<ScheduleDraftResponse> {
+  const res = await fetch('/api/schedules/draft/stream', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -51,7 +60,53 @@ export async function draftSchedules(prompt: string): Promise<ScheduleDraftRespo
     throw new Error(errorData.error || 'Failed to draft schedules');
   }
 
-  return res.json();
+  if (!res.body) {
+    throw new Error('Schedule draft stream is unavailable');
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let result: ScheduleDraftResponse | null = null;
+
+  const readEvent = (line: string) => {
+    const event = JSON.parse(line) as ScheduleDraftStreamEvent;
+
+    if (event.type === 'progress') {
+      onProgress?.({ title: event.title, detail: event.detail });
+      return;
+    }
+
+    if (event.type === 'result') {
+      result = event.result;
+      return;
+    }
+
+    if (event.type === 'error') {
+      throw new Error(event.error);
+    }
+
+    throw new Error('Unknown schedule draft stream event');
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (line.trim()) readEvent(line);
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.trim()) readEvent(buffer);
+  if (!result) throw new Error('OpenAI returned no schedule draft');
+
+  return result;
 }
 
 export async function updateSchedule(name: string, updates: Partial<ScheduleInput>) {

--- a/cloud-v3/src/lib/cron.ts
+++ b/cloud-v3/src/lib/cron.ts
@@ -1,0 +1,30 @@
+import cronParser from "cron-parser";
+import cronstrue from "cronstrue";
+
+export function validateCronExpression(expression: string): boolean {
+  try {
+    if (expression.trim().split(/\s+/).length !== 5) return false;
+    describeCronExpression(expression);
+    getNextCronExecutions(expression, "UTC", 1);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function describeCronExpression(expression: string): string {
+  return cronstrue.toString(expression);
+}
+
+export function getNextCronExecutions(
+  expression: string,
+  timezone: string,
+  count = 5
+): string[] {
+  const interval = cronParser.parseExpression(expression, {
+    currentDate: new Date(),
+    tz: timezone,
+  });
+
+  return Array.from({ length: count }, () => interval.next().toISOString());
+}

--- a/cloud-v3/src/lib/schedule-drafts.ts
+++ b/cloud-v3/src/lib/schedule-drafts.ts
@@ -1,0 +1,239 @@
+import { config, secrets } from "@/config";
+import {
+  describeCronExpression,
+  getNextCronExecutions,
+  validateCronExpression,
+} from "@/lib/cron";
+import { ApiError } from "@/lib/api";
+import { Schedule, ScheduleDraftResponse } from "@/types/schedule";
+
+type ModelScheduleDraftResponse = {
+  interpretation: string;
+  drafts: Array<{
+    name: string;
+    action: "open" | "close";
+    cron_expression: string;
+    enabled: boolean;
+    summary: string;
+  }>;
+  questions: string[];
+  warnings: string[];
+};
+
+const SCHEDULE_DRAFT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["interpretation", "drafts", "questions", "warnings"],
+  properties: {
+    interpretation: { type: "string" },
+    drafts: {
+      type: "array",
+      maxItems: 6,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["name", "action", "cron_expression", "enabled", "summary"],
+        properties: {
+          name: { type: "string" },
+          action: { type: "string", enum: ["open", "close"] },
+          cron_expression: { type: "string" },
+          enabled: { type: "boolean" },
+          summary: { type: "string" },
+        },
+      },
+    },
+    questions: { type: "array", items: { type: "string" }, maxItems: 3 },
+    warnings: { type: "array", items: { type: "string" }, maxItems: 5 },
+  },
+} as const;
+
+const SYSTEM_PROMPT = `
+You convert plain English into gate schedule drafts.
+
+Rules:
+- Return drafts only. Never open or close the gate immediately.
+- The scheduler supports only recurring five-field cron: minute hour day-of-month month day-of-week.
+- Use the supplied controller timezone for interpreting times.
+- Use 24-hour values in cron expressions.
+- Use action "open" only for opening and "close" only for closing.
+- If the request needs one-time dates, exceptions, holidays, sensors, sunrise/sunset, or unclear timing, do not guess. Return no drafts and add a concise question.
+- If the user asks for multiple actions, return multiple drafts.
+- Names must be short, human readable, and unique against the existing schedule names.
+- Default drafts to enabled.
+`.trim();
+
+export async function draftSchedules(
+  prompt: string,
+  existingSchedules: Schedule[]
+): Promise<ScheduleDraftResponse> {
+  if (!secrets.openaiApiKey) {
+    throw new ApiError(503, "AI schedule drafting is not configured. Set OPENAI_API_KEY.");
+  }
+
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${secrets.openaiApiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: config.scheduleDraftModel,
+      store: false,
+      input: [
+        { role: "developer", content: SYSTEM_PROMPT },
+        {
+          role: "user",
+          content: JSON.stringify({
+            controller_timezone: config.controllerTimezone,
+            existing_schedule_names: existingSchedules.map((schedule) => schedule.name),
+            request: prompt,
+          }),
+        },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "gate_schedule_draft",
+          strict: true,
+          schema: SCHEDULE_DRAFT_SCHEMA,
+        },
+      },
+    }),
+  });
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new ApiError(response.status, openAiErrorMessage(response.status, body));
+  }
+
+  return normalizeDraftResponse(parseModelResponse(body), existingSchedules);
+}
+
+function parseModelResponse(body: unknown): ModelScheduleDraftResponse {
+  const outputText = extractOutputText(body);
+  if (!outputText) throw new ApiError(502, "OpenAI returned no schedule draft");
+
+  try {
+    return JSON.parse(outputText) as ModelScheduleDraftResponse;
+  } catch {
+    throw new ApiError(502, "OpenAI returned an invalid schedule draft");
+  }
+}
+
+function normalizeDraftResponse(
+  response: ModelScheduleDraftResponse,
+  existingSchedules: Schedule[]
+): ScheduleDraftResponse {
+  const usedNames = new Set(existingSchedules.map((schedule) => schedule.name));
+  const warnings = [...cleanStringArray(response.warnings)];
+  const rawDrafts = Array.isArray(response.drafts) ? response.drafts : [];
+
+  const drafts = rawDrafts.flatMap((draft) => {
+    if (!draft || typeof draft !== "object") return [];
+    if (draft.action !== "open" && draft.action !== "close") return [];
+    if (typeof draft.name !== "string" || typeof draft.cron_expression !== "string") {
+      return [];
+    }
+
+    if (!validateCronExpression(draft.cron_expression)) {
+      warnings.push(`Skipped invalid cron expression: ${draft.cron_expression}`);
+      return [];
+    }
+
+    const name = nextAvailableName(cleanName(draft.name), usedNames);
+    usedNames.add(name);
+
+    return {
+      name,
+      action: draft.action,
+      cron_expression: draft.cron_expression.trim(),
+      enabled: draft.enabled === true,
+      summary: typeof draft.summary === "string" ? draft.summary.trim() : "",
+      description: describeCronExpression(draft.cron_expression),
+      nextExecutions: getNextCronExecutions(
+        draft.cron_expression,
+        config.controllerTimezone,
+        5
+      ),
+    };
+  });
+
+  return {
+    interpretation:
+      typeof response.interpretation === "string" ? response.interpretation.trim() : "",
+    drafts,
+    questions: cleanStringArray(response.questions),
+    warnings,
+  };
+}
+
+function extractOutputText(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  if ("output_text" in body && typeof body.output_text === "string") {
+    return body.output_text;
+  }
+
+  if (!("output" in body) || !Array.isArray(body.output)) return null;
+
+  for (const item of body.output) {
+    if (!item || typeof item !== "object") continue;
+    if (!("content" in item) || !Array.isArray(item.content)) continue;
+
+    for (const content of item.content) {
+      if (!content || typeof content !== "object") continue;
+      if ("text" in content && typeof content.text === "string") {
+        return content.text;
+      }
+    }
+  }
+
+  return null;
+}
+
+function openAiErrorMessage(status: number, body: unknown): string {
+  if (status === 401 || status === 403) {
+    return "OpenAI rejected OPENAI_API_KEY";
+  }
+  if (status === 429) {
+    return "OpenAI rate limit reached";
+  }
+
+  const type = readOpenAiErrorType(body);
+  return type ? `OpenAI schedule draft failed: ${type}` : "OpenAI schedule draft failed";
+}
+
+function readOpenAiErrorType(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  if (!("error" in body) || !body.error || typeof body.error !== "object") return null;
+  if (!("type" in body.error) || typeof body.error.type !== "string") return null;
+  return body.error.type;
+}
+
+function cleanStringArray(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function cleanName(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return cleaned || "gate schedule";
+}
+
+function nextAvailableName(name: string, usedNames: Set<string>): string {
+  if (!usedNames.has(name)) return name;
+
+  for (let suffix = 2; suffix < 100; suffix += 1) {
+    const candidate = `${name} ${suffix}`;
+    if (!usedNames.has(candidate)) return candidate;
+  }
+
+  return `${name} ${Date.now()}`;
+}

--- a/cloud-v3/src/lib/schedule-drafts.ts
+++ b/cloud-v3/src/lib/schedule-drafts.ts
@@ -5,7 +5,11 @@ import {
   validateCronExpression,
 } from "@/lib/cron";
 import { ApiError } from "@/lib/api";
-import { Schedule, ScheduleDraftResponse } from "@/types/schedule";
+import {
+  Schedule,
+  ScheduleDraftProgress,
+  ScheduleDraftResponse,
+} from "@/types/schedule";
 
 type ModelScheduleDraftResponse = {
   interpretation: string;
@@ -64,19 +68,18 @@ Rules:
 
 export async function draftSchedules(
   prompt: string,
-  existingSchedules: Schedule[]
+  existingSchedules: Schedule[],
+  onProgress?: (progress: ScheduleDraftProgress) => void
 ): Promise<ScheduleDraftResponse> {
-  if (!secrets.openaiApiKey) {
-    throw new ApiError(503, "AI schedule drafting is not configured. Set OPENAI_API_KEY.");
-  }
+  requireScheduleDraftingConfigured();
 
-  const response = await fetch("https://api.openai.com/v1/responses", {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${secrets.openaiApiKey}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
+  onProgress?.({
+    title: "Thinking through the schedule",
+    detail: "Asking AI for recurring open/close drafts in controller time.",
+  });
+
+  const response = await fetchOpenAiDraft(
+    JSON.stringify({
       model: config.scheduleDraftModel,
       store: false,
       input: [
@@ -99,14 +102,52 @@ export async function draftSchedules(
         },
       },
     }),
-  });
+    onProgress
+  );
 
   const body = await response.json().catch(() => null);
   if (!response.ok) {
     throw new ApiError(response.status, openAiErrorMessage(response.status, body));
   }
 
+  onProgress?.({
+    title: "Validating drafts",
+    detail: "Checking cron expressions and previewing upcoming run times.",
+  });
+
   return normalizeDraftResponse(parseModelResponse(body), existingSchedules);
+}
+
+export function requireScheduleDraftingConfigured() {
+  if (!secrets.openaiApiKey) {
+    throw new ApiError(503, "AI schedule drafting is not configured. Set OPENAI_API_KEY.");
+  }
+}
+
+async function fetchOpenAiDraft(
+  body: string,
+  onProgress?: (progress: ScheduleDraftProgress) => void
+) {
+  try {
+    return await postOpenAiDraft(body);
+  } catch {
+    onProgress?.({
+      title: "Retrying AI request",
+      detail: "The connection dropped before OpenAI replied; trying once more.",
+    });
+    return postOpenAiDraft(body);
+  }
+}
+
+function postOpenAiDraft(body: string) {
+  return fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${secrets.openaiApiKey}`,
+      "content-type": "application/json",
+    },
+    body,
+  });
 }
 
 function parseModelResponse(body: unknown): ModelScheduleDraftResponse {

--- a/cloud-v3/src/lib/scheduler.ts
+++ b/cloud-v3/src/lib/scheduler.ts
@@ -1,7 +1,7 @@
 import { config } from "@/config";
 import { Schedule } from "@/types/schedule";
 import { Queue, QueueEvents, Worker } from "bullmq";
-import cronstrue from "cronstrue";
+export { validateCronExpression } from "@/lib/cron";
 import { getSchedule, updateGateStatus } from "./db";
 
 const REDIS_CONNECTION_CONFIG = {
@@ -63,19 +63,6 @@ function getSchedulerRuntime(): SchedulerRuntime {
   }
 
   return globalForScheduler.gateSchedulerRuntime;
-}
-
-/**
- * Validates a cron expression
- */
-export function validateCronExpression(expression: string): boolean {
-  try {
-    cronstrue.toString(expression);
-    return true;
-  } catch (error) {
-    console.error("Invalid cron expression:", error);
-    return false;
-  }
 }
 
 /**

--- a/cloud-v3/src/types/schedule.ts
+++ b/cloud-v3/src/types/schedule.ts
@@ -19,6 +19,16 @@ export type ScheduleDraftResponse = {
   warnings: string[];
 };
 
+export type ScheduleDraftProgress = {
+  title: string;
+  detail: string;
+};
+
+export type ScheduleDraftStreamEvent =
+  | ({ type: 'progress' } & ScheduleDraftProgress)
+  | { type: 'result'; result: ScheduleDraftResponse }
+  | { type: 'error'; error: string };
+
 export type ScheduleInput = Pick<
   Schedule,
   'name' | 'cron_expression' | 'action' | 'enabled'

--- a/cloud-v3/src/types/schedule.ts
+++ b/cloud-v3/src/types/schedule.ts
@@ -6,6 +6,19 @@ export interface Schedule {
   created_by?: string;
 }
 
+export type ScheduleDraft = ScheduleInput & {
+  description: string;
+  nextExecutions: string[];
+  summary: string;
+};
+
+export type ScheduleDraftResponse = {
+  interpretation: string;
+  drafts: ScheduleDraft[];
+  questions: string[];
+  warnings: string[];
+};
+
 export type ScheduleInput = Pick<
   Schedule,
   'name' | 'cron_expression' | 'action' | 'enabled'

--- a/cloud-v3/tests/e2e/gate-controller.spec.ts
+++ b/cloud-v3/tests/e2e/gate-controller.spec.ts
@@ -118,6 +118,7 @@ test("AI schedule drafting works end-to-end", async ({ page }) => {
     .fill("Open the gate every weekday at 7:30 AM.");
   await page.getByRole("button", { name: "Draft" }).click();
 
+  await expect(page.getByText("No gate command is being sent.")).toBeVisible();
   await expect(page.getByText("Review Drafts")).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("button", { name: "Apply All" })).toBeVisible();
   await page.getByRole("button", { name: "Apply All" }).click();

--- a/cloud-v3/tests/e2e/gate-controller.spec.ts
+++ b/cloud-v3/tests/e2e/gate-controller.spec.ts
@@ -31,7 +31,7 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
   await expect(page.getByText("CLOSED")).toBeVisible();
 
   await page.getByRole("button", { name: "Open Gate" }).click();
-  await expect(page.getByText("OPEN")).toBeVisible();
+  await expect(page.getByText("OPEN", { exact: true })).toBeVisible();
 
   const openedAgentStatus = await request.post("/api/gate/take_status", {
     headers: { Authorization: `Bearer ${agentToken}` },
@@ -98,4 +98,62 @@ test("gate controller works end-to-end", async ({ browser, page, request }) => {
     .getByRole("button", { name: "Delete" })
     .click();
   await expect(page.getByRole("cell", { name: scheduleName })).toHaveCount(0);
+});
+
+test("AI schedule drafting works end-to-end", async ({ page }) => {
+  if (!process.env.E2E_OPENAI_API_KEY) {
+    throw new Error("E2E_OPENAI_API_KEY is required for AI schedule drafting E2E");
+  }
+
+  await login(page, admin.username, admin.password);
+
+  const before = await browserJson(page, "/api/schedules");
+  expect(before.status).toBe(200);
+  const existingNames = new Set(
+    (before.body as Array<{ name: string }>).map((schedule) => schedule.name)
+  );
+
+  await page
+    .getByLabel("Describe schedule")
+    .fill("Open the gate every weekday at 7:30 AM.");
+  await page.getByRole("button", { name: "Draft" }).click();
+
+  await expect(page.getByText("Review Drafts")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Apply All" })).toBeVisible();
+  await page.getByRole("button", { name: "Apply All" }).click();
+
+  let createdSchedules: Array<{
+    action: "open" | "close";
+    cron_expression: string;
+    enabled: boolean;
+    name: string;
+  }> = [];
+
+  await expect
+    .poll(async () => {
+      const response = await browserJson(page, "/api/schedules");
+      expect(response.status).toBe(200);
+      createdSchedules = (
+        response.body as Array<{
+          action: "open" | "close";
+          cron_expression: string;
+          enabled: boolean;
+          name: string;
+        }>
+      ).filter((schedule) => !existingNames.has(schedule.name));
+      return createdSchedules.length;
+    })
+    .toBeGreaterThan(0);
+
+  for (const schedule of createdSchedules) {
+    expect(schedule.action).toBe("open");
+    expect(schedule.cron_expression.trim().split(/\s+/)).toHaveLength(5);
+    expect(schedule.enabled).toBe(true);
+    await expect(page.getByRole("cell", { name: schedule.name })).toBeVisible();
+    expect(
+      await browserJson(page, `/api/schedules?name=${encodeURIComponent(schedule.name)}`, {
+        method: "DELETE",
+      })
+    ).toEqual({ status: 204, body: null });
+  }
 });

--- a/cloud-v3/tests/integration/api-routes.spec.ts
+++ b/cloud-v3/tests/integration/api-routes.spec.ts
@@ -19,6 +19,7 @@ test("api routes enforce auth and controlled edge errors", async ({
     { method: "GET", url: "/api/schedules/upcoming" },
     { method: "POST", url: "/api/schedules" },
     { method: "POST", url: "/api/schedules/draft" },
+    { method: "POST", url: "/api/schedules/draft/stream" },
     { method: "GET", url: "/api/users" },
   ]) {
     const response =
@@ -136,15 +137,17 @@ test("api routes enforce auth and controlled edge errors", async ({
     body: { error: "Invalid action" },
   });
   if (!process.env.E2E_OPENAI_API_KEY) {
-    expect(
-      await browserJson(page, "/api/schedules/draft", {
-        body: { prompt: "Open weekdays at 8 AM" },
-        method: "POST",
-      })
-    ).toEqual({
-      status: 503,
-      body: { error: "AI schedule drafting is not configured. Set OPENAI_API_KEY." },
-    });
+    for (const url of ["/api/schedules/draft", "/api/schedules/draft/stream"]) {
+      expect(
+        await browserJson(page, url, {
+          body: { prompt: "Open weekdays at 8 AM" },
+          method: "POST",
+        })
+      ).toEqual({
+        status: 503,
+        body: { error: "AI schedule drafting is not configured. Set OPENAI_API_KEY." },
+      });
+    }
   }
 
   expect(

--- a/cloud-v3/tests/integration/api-routes.spec.ts
+++ b/cloud-v3/tests/integration/api-routes.spec.ts
@@ -18,6 +18,7 @@ test("api routes enforce auth and controlled edge errors", async ({
     { method: "GET", url: "/api/schedules" },
     { method: "GET", url: "/api/schedules/upcoming" },
     { method: "POST", url: "/api/schedules" },
+    { method: "POST", url: "/api/schedules/draft" },
     { method: "GET", url: "/api/users" },
   ]) {
     const response =
@@ -134,6 +135,17 @@ test("api routes enforce auth and controlled edge errors", async ({
     status: 400,
     body: { error: "Invalid action" },
   });
+  if (!process.env.E2E_OPENAI_API_KEY) {
+    expect(
+      await browserJson(page, "/api/schedules/draft", {
+        body: { prompt: "Open weekdays at 8 AM" },
+        method: "POST",
+      })
+    ).toEqual({
+      status: 503,
+      body: { error: "AI schedule drafting is not configured. Set OPENAI_API_KEY." },
+    });
+  }
 
   expect(
     await browserJson(page, "/api/users", {


### PR DESCRIPTION
## Summary

- Add an AI schedule drafting endpoint that turns natural-language schedule requests into validated draft schedules.
- Add a review/apply UX for draft schedules while keeping manual cron entry available.
- Stream user-facing drafting progress events so the UI shows what stage it is in without exposing model chain-of-thought.
- Wire CI to run the live OpenAI-backed E2E path with `E2E_OPENAI_API_KEY` and fail loudly when the secret is missing.

## Validation

- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `E2E_OPENAI_API_KEY=... npm run e2e` -> 3 passed

## Notes

- Streaming uses newline-delimited progress/result events from `/api/schedules/draft/stream`.
- The streamed trace is operational status, not private model reasoning.
- OpenAI auth, rate-limit, missing-key, malformed-response, and transport-drop cases fail loudly with user-visible errors.